### PR TITLE
Fix fetch and rebuild workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -13,42 +13,14 @@ on:
       release-version:
         description: 'A specific version to bump to. Mutually exclusive with "release-type".'
         required: false
-  workflow_run:
-    branches: [main]
-    types:
-      - completed
-    workflows: [Fetch and Rebuild]
 
 jobs:
-  check-trigger:
-    runs-on: ubuntu-latest
-    steps:
-      - if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure' }}
-        run: exit 1
-
   create-release-pr:
-    needs: check-trigger
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - name: Set base branch
-        id: set-base-branch
-        run: |
-          input_base_branch=${{ github.event.inputs.base-branch }}
-          base_branch=${input_base_branch:-'main'}
-          echo ::set-output name=BASE_BRANCH::$base_branch
-
-      - name: Set release type
-        id: set-release-type
-        run: |
-          release_type=${{ github.event.inputs.release-type }}
-          if ${{ github.event_name == 'workflow_run' }}; then
-            release_type=${release_type:-'minor'}
-          fi
-          echo ::set-output name=RELEASE_TYPE::$release_type
-
       - uses: actions/checkout@v2
         with:
           # This is to guarantee that the most recent tag is fetched.
@@ -56,7 +28,7 @@ jobs:
           fetch-depth: 0
           # We check out the specified branch, which will be used as the base
           # branch for all git operations and the release PR.
-          ref: ${{ steps.set-base-branch.outputs.BASE_BRANCH }}
+          ref: ${{ github.event.inputs.base-branch }}
       - name: Get Node.js version
         id: nvm
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
@@ -67,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          release-type: ${{ steps.set-release-type.outputs.RELEASE_TYPE }}
+          release-type: ${{ github.event.inputs.release-type }}
           release-version: ${{ github.event.inputs.release-version }}
           artifacts-path: gh-action__release-authors
       # Upload the release author artifact for use in subsequent workflows

--- a/.github/workflows/fetch-and-rebuild.yml
+++ b/.github/workflows/fetch-and-rebuild.yml
@@ -10,6 +10,7 @@ jobs:
     name: Fetch and rebuild
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
 
     steps:

--- a/.github/workflows/fetch-and-rebuild.yml
+++ b/.github/workflows/fetch-and-rebuild.yml
@@ -10,7 +10,7 @@ jobs:
     name: Fetch and rebuild
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      pull-requests: write
 
     steps:
       - name: Get current date
@@ -33,5 +33,7 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn allow-scripts
 
-      - name: Fetch, rebuild, push, and trigger Create Release Pull Request
+      - name: Fetch, rebuild, create pull request
         run: yarn rebuild:ci ${{ steps.date.outputs.date }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fetch-and-rebuild.yml
+++ b/.github/workflows/fetch-and-rebuild.yml
@@ -6,9 +6,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  fetch-and-rebuild:
     name: Fetch and rebuild
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Get current date

--- a/scripts/fetch-rebuild-push.sh
+++ b/scripts/fetch-rebuild-push.sh
@@ -23,9 +23,16 @@ yarn build:clean
 yarn lint:fix
 yarn test
 
+PR_TITLE="Update with latest data as of ${CURRENT_DATE}"
+
 git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
 
+git checkout -b "update-slip44-${CURRENT_DATE}"
+
 git add .
-git commit -m "Update with latest data as of ${CURRENT_DATE}"
-git push -u origin main
+git commit -m "${PR_TITLE}"
+
+gh pr create \
+  --title "${PR_TITLE}" \
+  --body "Updates the package with the latest SLIP-44 data as of ${CURRENT_DATE}." 

--- a/scripts/fetch-rebuild-push.sh
+++ b/scripts/fetch-rebuild-push.sh
@@ -23,16 +23,20 @@ yarn build:clean
 yarn lint:fix
 yarn test
 
+BRANCH_NAME="update-slip44-${CURRENT_DATE}"
 PR_TITLE="Update with latest data as of ${CURRENT_DATE}"
 
 git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
 
-git checkout -b "update-slip44-${CURRENT_DATE}"
+git checkout -b "${BRANCH_NAME}"
 
 git add .
 git commit -m "${PR_TITLE}"
 
+git push --set-upstream origin "${BRANCH_NAME}"
+
 gh pr create \
   --title "${PR_TITLE}" \
+  --head "${BRANCH_NAME}" \
   --body "Updates the package with the latest SLIP-44 data as of ${CURRENT_DATE}." 


### PR DESCRIPTION
The approach taken in #11 was unsound due to branch protection. This PR changes the workflow to create a PR with the new SLIP-44 data instead of pushing directly to `main`. If we want to do the latter we'd have to create a bot and grant it special permissions.