### PR TITLE
EOS rebranded to Vaulta

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/slip44.json
+++ b/slip44.json
@@ -1166,8 +1166,8 @@
   "194": {
     "index": "194",
     "hex": "0x800000c2",
-    "symbol": "EOS",
-    "name": "EOS"
+    "symbol": "A",
+    "name": "Vaulta"
   },
   "195": {
     "index": "195",

--- a/src/slip44.md
+++ b/src/slip44.md
@@ -27,7 +27,7 @@ These are the registered coin types for usage in level 2 of BIP44 described in c
 All these constants are used as hardened derivation.
 
 | Coin type  | Path component (`coin_type'`) | Symbol  | Coin                              |
-| ---------- | ----------------------------- | ------- | --------------------------------- |
+| ---------- | ----------------------------- |---------|-----------------------------------|
 | 0          | 0x80000000                    | BTC     | Bitcoin                           |
 | 1          | 0x80000001                    |         | Testnet (all coins)               |
 | 2          | 0x80000002                    | LTC     | Litecoin                          |
@@ -222,7 +222,7 @@ All these constants are used as hardened derivation.
 | 191        | 0x800000bf                    |         | Lynx                              |
 | 192        | 0x800000c0                    | LCC     | LitecoinCash                      |
 | 193        | 0x800000c1                    | XFE     | Feirm                             |
-| 194        | 0x800000c2                    | EOS     | EOS                               |
+| 194        | 0x800000c2                    | A       | Vaulta                            |
 | 195        | 0x800000c3                    | TRX     | Tron                              |
 | 196        | 0x800000c4                    | KOBO    | Kobocoin                          |
 | 197        | 0x800000c5                    | HUSH    | HUSH                              |


### PR DESCRIPTION
I opened an [issue](https://github.com/MetaMask/slip44/issues/181) asking if this is the correct way to do this a bit ago, but figured might as well PR it and find out!

https://www.vaulta.com/resources/vaulta-token-swap-live
https://eosnetwork.com/resources/opening-the-gateway-to-web3-banking/

As part of a snap for Vaulta (there's an EOS snap created by the greymass team cc @aaroncox) changing this will allow the name of the network to show up properly whereas right now it only shows EOS as far as I understand. 