### PR TITLE
Update CODEOWNERS to `core-platform`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/snaps-devs
+*                                    @MetaMask/core-platform


### PR DESCRIPTION
Adjust CODEOWNERS to the `core-platform` team which now includes `snaps-devs`.