### PR TITLE
fix: Loosen validation a bit to account for invalid Markdown

### DIFF
--- a/slip44.json
+++ b/slip44.json
@@ -4943,6 +4943,12 @@
     "symbol": "LUM",
     "name": "Lum Network"
   },
+  "881": {
+    "index": "881",
+    "hex": "0x80000371",
+    "symbol": "AEGS",
+    "name": "Aegisum"
+  },
   "883": {
     "index": "883",
     "hex": "0x80000373",

--- a/src/build.js
+++ b/src/build.js
@@ -9,10 +9,10 @@ const slip44Content = fs.readFileSync(rawSlip44Path, 'utf8');
 
 const entries = {};
 for (const line of slip44Content.split('\n')) {
-  const segments = line.split('|').slice(1, -1);
+  const segments = line.split('|').slice(1);
   if (
-    segments.length === 4 &&
-    /^\|\s*\d+\s*\|\s*0x[a-z0-9]+\s*\|/iu.test(line)
+    segments.length >= 4 &&
+    /^\|\s*\d+\s*\|\s*0x[a-z0-9]+\s*\|\s.+\|\s.+\|?$/iu.test(line)
   ) {
     // eslint-disable-next-line id-denylist
     const [index, hex, symbol, name] = segments.map((seg) => seg.trim());


### PR DESCRIPTION
Loosen validation of each line a bit to allow for invalid Markdown to still be parsed correctly.