### PR TITLE
fix: Support SLIP44 format changes

### DIFF
--- a/slip44.json
+++ b/slip44.json
@@ -5627,6 +5627,30 @@
     "symbol": "",
     "name": "Nostr"
   },
+  "1238": {
+    "index": "1238",
+    "hex": "0x800004d6",
+    "symbol": "",
+    "name": "SSH"
+  },
+  "1239": {
+    "index": "1239",
+    "hex": "0x800004d7",
+    "symbol": "",
+    "name": "OpenPGP"
+  },
+  "1240": {
+    "index": "1240",
+    "hex": "0x800004d8",
+    "symbol": "",
+    "name": "X.509"
+  },
+  "1241": {
+    "index": "1241",
+    "hex": "0x800004d9",
+    "symbol": "",
+    "name": "WireGuard"
+  },
   "1280": {
     "index": "1280",
     "hex": "0x80000500",
@@ -5675,6 +5699,12 @@
     "symbol": "GAEL",
     "name": "Gaelium"
   },
+  "1331": {
+    "index": "1331",
+    "hex": "0x80000533",
+    "symbol": "NACKL",
+    "name": "Acki Nacki"
+  },
   "1337": {
     "index": "1337",
     "hex": "0x80000539",
@@ -5722,6 +5752,12 @@
     "hex": "0x800005a7",
     "symbol": "DNR",
     "name": "Dinero"
+  },
+  "1448": {
+    "index": "1448",
+    "hex": "0x800005a8",
+    "symbol": "DIN",
+    "name": "Dinero v7"
   },
   "1510": {
     "index": "1510",
@@ -5878,6 +5914,12 @@
     "hex": "0x8000071a",
     "symbol": "CUBE",
     "name": "Cube Chain Native Token"
+  },
+  "1842": {
+    "index": "1842",
+    "hex": "0x80000732",
+    "symbol": "LIF",
+    "name": "Lifcoin"
   },
   "1888": {
     "index": "1888",
@@ -6509,6 +6551,12 @@
     "symbol": "YEE",
     "name": "YeeCo"
   },
+  "4134": {
+    "index": "4134",
+    "hex": "0x80001026",
+    "symbol": "DMD",
+    "name": "DebitMyData"
+  },
   "4218": {
     "index": "4218",
     "hex": "0x8000107a",
@@ -6529,7 +6577,7 @@
   },
   "4298": {
     "index": "4298",
-    "hex": "0x800010CA",
+    "hex": "0x800010ca",
     "symbol": "LOCA",
     "name": "Loca"
   },
@@ -6586,6 +6634,12 @@
     "hex": "0x8000138e",
     "symbol": "SBC",
     "name": "Senior Blockchain"
+  },
+  "5042": {
+    "index": "5042",
+    "hex": "0x800013b2",
+    "symbol": "USDC",
+    "name": "Arc"
   },
   "5248": {
     "index": "5248",
@@ -6725,6 +6779,12 @@
     "symbol": "ZETA",
     "name": "ZetaChain"
   },
+  "7007": {
+    "index": "7007",
+    "hex": "0x80001b5f",
+    "symbol": "SVRN7",
+    "name": "Web 7.0 Sovrona"
+  },
   "7027": {
     "index": "7027",
     "hex": "0x80001b73",
@@ -6839,6 +6899,12 @@
     "symbol": "HANEUL",
     "name": "Haneul"
   },
+  "8327": {
+    "index": "8327",
+    "hex": "0x80002087",
+    "symbol": "RXB",
+    "name": "Record X-core Blockchain"
+  },
   "8339": {
     "index": "8339",
     "hex": "0x80002093",
@@ -6874,6 +6940,12 @@
     "hex": "0x80002222",
     "symbol": "ALPH",
     "name": "Alph Network"
+  },
+  "8800": {
+    "index": "8800",
+    "hex": "0x80002260",
+    "symbol": "AIIR",
+    "name": "BitAiir"
   },
   "8866": {
     "index": "8866",
@@ -6971,11 +7043,23 @@
     "symbol": "SATOX",
     "name": "Satoxcoin"
   },
+  "9333": {
+    "index": "9333",
+    "hex": "0x80002475",
+    "symbol": "B3C",
+    "name": "B3Chain"
+  },
   "9345": {
     "index": "9345",
     "hex": "0x80002481",
     "symbol": "WEIL",
     "name": "Weilliptic"
+  },
+  "9508": {
+    "index": "9508",
+    "hex": "0x80002524",
+    "symbol": "VARTA",
+    "name": "Monetarium"
   },
   "9555": {
     "index": "9555",
@@ -7127,6 +7211,12 @@
     "symbol": "WAX",
     "name": "Worldwide Asset Exchange"
   },
+  "14159": {
+    "index": "14159",
+    "hex": "0x8000374f",
+    "symbol": "FBC",
+    "name": "Fistbump"
+  },
   "15845": {
     "index": "15845",
     "hex": "0x80003de5",
@@ -7180,6 +7270,12 @@
     "hex": "0x80004d4c",
     "symbol": "ML",
     "name": "Mintlayer"
+  },
+  "19999": {
+    "index": "19999",
+    "hex": "0x80004e1f",
+    "symbol": "CS",
+    "name": "Cloud Service"
   },
   "20036": {
     "index": "20036",
@@ -7240,6 +7336,12 @@
     "hex": "0x80006731",
     "symbol": "G1",
     "name": "Ğ1"
+  },
+  "28465": {
+    "index": "28465",
+    "hex": "0x80006f31",
+    "symbol": "BTCC",
+    "name": "Bitcoin-Classic"
   },
   "29223": {
     "index": "29223",
@@ -7345,7 +7447,7 @@
   },
   "61888": {
     "index": "61888",
-    "hex": "0x8000f200",
+    "hex": "0x8000f1c0",
     "symbol": "MORM",
     "name": "Morpheum"
   },
@@ -7354,6 +7456,12 @@
     "hex": "0x80010000",
     "symbol": "KETH",
     "name": "Krypton World"
+  },
+  "68291": {
+    "index": "68291",
+    "hex": "0x80010ac3",
+    "symbol": "CERA",
+    "name": "CERA"
   },
   "69420": {
     "index": "69420",
@@ -7438,6 +7546,12 @@
     "hex": "0x8001ff06",
     "symbol": "WBT",
     "name": "WhiteBIT Coin"
+  },
+  "140586": {
+    "index": "140586",
+    "hex": "0x8002252a",
+    "symbol": "BEX",
+    "name": "BEXChain"
   },
   "161803": {
     "index": "161803",
@@ -7537,7 +7651,7 @@
   },
   "696365": {
     "index": "696365",
-    "hex": "0x800b3206",
+    "hex": "0x800aa02d",
     "symbol": "ICE",
     "name": "Ice Network"
   },
@@ -7612,6 +7726,12 @@
     "hex": "0x803be02b",
     "symbol": "EPK",
     "name": "EPIK Protocol"
+  },
+  "4151811": {
+    "index": "4151811",
+    "hex": "0x803f5a03",
+    "symbol": "DORK",
+    "name": "Dorkcoin"
   },
   "4353123": {
     "index": "4353123",
@@ -7741,7 +7861,7 @@
   },
   "10000118": {
     "index": "10000118",
-    "hex": "0x805d30b6",
+    "hex": "0x809896f6",
     "symbol": "OSMO",
     "name": "Osmosis"
   },
@@ -7774,6 +7894,12 @@
     "hex": "0x8134d82e",
     "symbol": "NLK",
     "name": "NuLinkCoin"
+  },
+  "20260424": {
+    "index": "20260424",
+    "hex": "0x81352648",
+    "symbol": "SOLEN",
+    "name": "Solen"
   },
   "22000118": {
     "index": "22000118",
@@ -7907,6 +8033,12 @@
     "symbol": "AME",
     "name": "AME Chain"
   },
+  "1414421071": {
+    "index": "1414421071",
+    "hex": "0xd44e5a4f",
+    "symbol": "TNZO",
+    "name": "Tenzro"
+  },
   "1869902945": {
     "index": "1869902945",
     "hex": "0xef747461",
@@ -7918,5 +8050,11 @@
     "hex": "0xef747462",
     "symbol": "CTA",
     "name": "Crypterra"
+  },
+  "1869902947": {
+    "index": "1869902947",
+    "hex": "0xef747463",
+    "symbol": "SOST",
+    "name": "Sovereign Stock Token"
   }
 }

--- a/src/build.js
+++ b/src/build.js
@@ -11,11 +11,19 @@ const entries = {};
 for (const line of slip44Content.split('\n')) {
   const segments = line.split('|').slice(1);
   if (
-    segments.length >= 4 &&
-    /^\|\s*\d+\s*\|\s*0x[a-z0-9]+\s*\|\s.+\|\s.+\|?$/iu.test(line)
+    segments.length >= 3 &&
+    /^\|\s*\d+\s*\|\s.+\|\s.+\|?$/iu.test(line)
   ) {
+    const [index, symbol, name] = segments.map((seg) => seg.trim());
+    
+    const coinType = (index | 0x80000000) >>> 0;
     // eslint-disable-next-line id-denylist
-    const [index, hex, symbol, name] = segments.map((seg) => seg.trim());
+    const hex = `0x${coinType.toString(16)}`;
+
+    // Ignore empty entries
+    if (symbol === '' && name === '') {
+      continue;
+    }
 
     // Ignore reserved entries
     if (symbol === '---' && name === 'reserved') {

--- a/src/build.js
+++ b/src/build.js
@@ -10,13 +10,12 @@ const slip44Content = fs.readFileSync(rawSlip44Path, 'utf8');
 const entries = {};
 for (const line of slip44Content.split('\n')) {
   const segments = line.split('|').slice(1);
-  if (
-    segments.length >= 3 &&
-    /^\|\s*\d+\s*\|\s.+\|\s.+\|?$/iu.test(line)
-  ) {
+  if (segments.length >= 3 && /^\|\s*\d+\s*\|\s.+\|\s.+\|?$/iu.test(line)) {
     const [index, symbol, name] = segments.map((seg) => seg.trim());
-    
+
+    // eslint-disable-next-line no-bitwise
     const coinType = (index | 0x80000000) >>> 0;
+
     // eslint-disable-next-line id-denylist
     const hex = `0x${coinType.toString(16)}`;
 

--- a/src/slip44.md
+++ b/src/slip44.md
@@ -26,1442 +26,1467 @@ These are the registered coin types for usage in level 2 of BIP44 described in c
 
 All these constants are used as hardened derivation.
 
-| Coin type  | Path component (`coin_type'`) | Symbol  | Coin                              |
-| ---------- | ----------------------------- | ------- | --------------------------------- |
-| 0          | 0x80000000                    | BTC     | Bitcoin                           |
-| 1          | 0x80000001                    |         | Testnet (all coins)               |
-| 2          | 0x80000002                    | LTC     | Litecoin                          |
-| 3          | 0x80000003                    | DOGE    | Dogecoin                          |
-| 4          | 0x80000004                    | RDD     | Reddcoin                          |
-| 5          | 0x80000005                    | DASH    | Dash                              |
-| 6          | 0x80000006                    | PPC     | Peercoin                          |
-| 7          | 0x80000007                    | NMC     | Namecoin                          |
-| 8          | 0x80000008                    | FTC     | Feathercoin                       |
-| 9          | 0x80000009                    | XCP     | Counterparty                      |
-| 10         | 0x8000000a                    | BLK     | Blackcoin                         |
-| 11         | 0x8000000b                    | NSR     | NuShares                          |
-| 12         | 0x8000000c                    | NBT     | NuBits                            |
-| 13         | 0x8000000d                    | MZC     | Mazacoin                          |
-| 14         | 0x8000000e                    | VIA     | Viacoin                           |
-| 15         | 0x8000000f                    | XCH     | ClearingHouse                     |
-| 16         | 0x80000010                    | RBY     | Rubycoin                          |
-| 17         | 0x80000011                    | GRS     | Groestlcoin                       |
-| 18         | 0x80000012                    | DGC     | Digitalcoin                       |
-| 19         | 0x80000013                    | CCN     | Cannacoin                         |
-| 20         | 0x80000014                    | DGB     | DigiByte                          |
-| 21         | 0x80000015                    |         | Open Assets                       |
-| 22         | 0x80000016                    | MONA    | Monacoin                          |
-| 23         | 0x80000017                    | CLAM    | Clams                             |
-| 24         | 0x80000018                    | XPM     | Primecoin                         |
-| 25         | 0x80000019                    | NEOS    | Neoscoin                          |
-| 26         | 0x8000001a                    | JBS     | Jumbucks                          |
-| 27         | 0x8000001b                    | ZRC     | ziftrCOIN                         |
-| 28         | 0x8000001c                    | VTC     | Vertcoin                          |
-| 29         | 0x8000001d                    | NXT     | NXT                               |
-| 30         | 0x8000001e                    | BURST   | Burst                             |
-| 31         | 0x8000001f                    | MUE     | MonetaryUnit                      |
-| 32         | 0x80000020                    | ZOOM    | Zoom                              |
-| 33         | 0x80000021                    | VASH    | Virtual Cash                      |
-| 34         | 0x80000022                    | CDN     | Canada eCoin                      |
-| 35         | 0x80000023                    | SDC     | ShadowCash                        |
-| 36         | 0x80000024                    | PKB     | ParkByte                          |
-| 37         | 0x80000025                    | PND     | Pandacoin                         |
-| 38         | 0x80000026                    | START   | StartCOIN                         |
-| 39         | 0x80000027                    | MOIN    | MOIN                              |
-| 40         | 0x80000028                    | EXP     | Expanse                           |
-| 41         | 0x80000029                    | EMC2    | Einsteinium                       |
-| 42         | 0x8000002a                    | DCR     | Decred                            |
-| 43         | 0x8000002b                    | XEM     | NEM                               |
-| 44         | 0x8000002c                    | PART    | Particl                           |
-| 45         | 0x8000002d                    | ARG     | Argentum (dead)                   |
-| 46         | 0x8000002e                    |         | Libertas                          |
-| 47         | 0x8000002f                    |         | Posw coin                         |
-| 48         | 0x80000030                    | SHR     | Shreeji                           |
-| 49         | 0x80000031                    | GCR     | Global Currency Reserve (GCRcoin) |
-| 50         | 0x80000032                    | NVC     | Novacoin                          |
-| 51         | 0x80000033                    | AC      | Asiacoin                          |
-| 52         | 0x80000034                    | BTCD    | BitcoinDark                       |
-| 53         | 0x80000035                    | DOPE    | Dopecoin                          |
-| 54         | 0x80000036                    | TPC     | Templecoin                        |
-| 55         | 0x80000037                    | AIB     | AIB                               |
-| 56         | 0x80000038                    | EDRC    | EDRCoin                           |
-| 57         | 0x80000039                    | SYS     | Syscoin                           |
-| 58         | 0x8000003a                    | SLR     | Solarcoin                         |
-| 59         | 0x8000003b                    | SMLY    | Smileycoin                        |
-| 60         | 0x8000003c                    | ETH     | Ether                             |
-| 61         | 0x8000003d                    | ETC     | Ether Classic                     |
-| 62         | 0x8000003e                    | PSB     | Pesobit                           |
-| 63         | 0x8000003f                    | LDCN    | Landcoin (dead)                   |
-| 64         | 0x80000040                    |         | Open Chain                        |
-| 65         | 0x80000041                    | XBC     | Bitcoinplus                       |
-| 66         | 0x80000042                    | IOP     | Internet of People                |
-| 67         | 0x80000043                    | NXS     | Nexus                             |
-| 68         | 0x80000044                    | INSN    | InsaneCoin                        |
-| 69         | 0x80000045                    | OK      | OKCash                            |
-| 70         | 0x80000046                    | BRIT    | BritCoin                          |
-| 71         | 0x80000047                    | CMP     | Compcoin                          |
-| 72         | 0x80000048                    | CRW     | Crown                             |
-| 73         | 0x80000049                    | BELA    | BelaCoin                          |
-| 74         | 0x8000004a                    | ICX     | ICON                              |
-| 75         | 0x8000004b                    | FJC     | FujiCoin                          |
-| 76         | 0x8000004c                    | MIX     | MIX                               |
-| 77         | 0x8000004d                    | XVG     | Verge Currency                    |
-| 78         | 0x8000004e                    | EFL     | Electronic Gulden                 |
-| 79         | 0x8000004f                    | CLUB    | ClubCoin                          |
-| 80         | 0x80000050                    | RICHX   | RichCoin                          |
-| 81         | 0x80000051                    | POT     | Potcoin                           |
-| 82         | 0x80000052                    | QRK     | Quarkcoin                         |
-| 83         | 0x80000053                    | TRC     | Terracoin                         |
-| 84         | 0x80000054                    | GRC     | Gridcoin                          |
-| 85         | 0x80000055                    | AUR     | Auroracoin                        |
-| 86         | 0x80000056                    | IXC     | IXCoin                            |
-| 87         | 0x80000057                    | NLG     | Gulden                            |
-| 88         | 0x80000058                    | BITB    | BitBean                           |
-| 89         | 0x80000059                    | BTA     | Bata                              |
-| 90         | 0x8000005a                    | XMY     | Myriadcoin                        |
-| 91         | 0x8000005b                    | BSD     | BitSend                           |
-| 92         | 0x8000005c                    | UNO     | Unobtanium                        |
-| 93         | 0x8000005d                    | MTR     | MasterTrader                      |
-| 94         | 0x8000005e                    | GB      | GoldBlocks                        |
-| 95         | 0x8000005f                    | SHM     | Saham                             |
-| 96         | 0x80000060                    | CRX     | Chronos                           |
-| 97         | 0x80000061                    | BIQ     | Ubiquoin                          |
-| 98         | 0x80000062                    | EVO     | Evotion                           |
-| 99         | 0x80000063                    | STO     | SaveTheOcean                      |
-| 100        | 0x80000064                    | BIGUP   | BigUp                             |
-| 101        | 0x80000065                    | GAME    | GameCredits                       |
-| 102        | 0x80000066                    | DLC     | Dollarcoins                       |
-| 103        | 0x80000067                    | ZYD     | Zayedcoin                         |
-| 104        | 0x80000068                    | DBIC    | Dubaicoin                         |
-| 105        | 0x80000069                    | STRAT   | Stratis                           |
-| 106        | 0x8000006a                    | SH      | Shilling                          |
-| 107        | 0x8000006b                    | MARS    | MarsCoin                          |
-| 108        | 0x8000006c                    | UBQ     | Ubiq                              |
-| 109        | 0x8000006d                    | PTC     | Pesetacoin                        |
-| 110        | 0x8000006e                    | NRO     | Neurocoin                         |
-| 111        | 0x8000006f                    | ARK     | ARK                               |
-| 112        | 0x80000070                    | USC     | UltimateSecureCashMain            |
-| 113        | 0x80000071                    | THC     | Hempcoin                          |
-| 114        | 0x80000072                    | LINX    | Linx                              |
-| 115        | 0x80000073                    | ECN     | Ecoin                             |
-| 116        | 0x80000074                    | DNR     | Denarius                          |
-| 117        | 0x80000075                    | PINK    | Pinkcoin                          |
-| 118        | 0x80000076                    | ATOM    | Atom                              |
-| 119        | 0x80000077                    | PIVX    | Pivx                              |
-| 120        | 0x80000078                    | FLASH   | Flashcoin                         |
-| 121        | 0x80000079                    | ZEN     | Zencash                           |
-| 122        | 0x8000007a                    | PUT     | Putincoin                         |
-| 123        | 0x8000007b                    | ZNY     | BitZeny                           |
-| 124        | 0x8000007c                    | UNIFY   | Unify                             |
-| 125        | 0x8000007d                    | XST     | StealthCoin                       |
-| 126        | 0x8000007e                    | BRK     | Breakout Coin                     |
-| 127        | 0x8000007f                    | VC      | Vcash                             |
-| 128        | 0x80000080                    | XMR     | Monero                            |
-| 129        | 0x80000081                    | VOX     | Voxels                            |
-| 130        | 0x80000082                    | NAV     | NavCoin                           |
-| 131        | 0x80000083                    | FCT     | Factom Factoids                   |
-| 132        | 0x80000084                    | EC      | Factom Entry Credits              |
-| 133        | 0x80000085                    | ZEC     | Zcash                             |
-| 134        | 0x80000086                    | LSK     | Lisk                              |
-| 135        | 0x80000087                    | STEEM   | Steem                             |
-| 136        | 0x80000088                    | XZC     | ZCoin                             |
-| 137        | 0x80000089                    | RBTC    | Rootstock                         |
-| 138        | 0x8000008a                    |         | Giftblock                         |
-| 139        | 0x8000008b                    | RPT     | RealPointCoin                     |
-| 140        | 0x8000008c                    | LBC     | LBRY Credits                      |
-| 141        | 0x8000008d                    | KMD     | Komodo                            |
-| 142        | 0x8000008e                    | BSQ     | bisq Token                        |
-| 143        | 0x8000008f                    | RIC     | Riecoin                           |
-| 144        | 0x80000090                    | XRP     | XRP                               |
-| 145        | 0x80000091                    | BCH     | Bitcoin Cash                      |
-| 146        | 0x80000092                    | NEBL    | Neblio                            |
-| 147        | 0x80000093                    | ZCL     | ZClassic                          |
-| 148        | 0x80000094                    | XLM     | Stellar Lumens                    |
-| 149        | 0x80000095                    | NLC2    | NoLimitCoin2                      |
-| 150        | 0x80000096                    | WHL     | WhaleCoin                         |
-| 151        | 0x80000097                    | ERC     | EuropeCoin                        |
-| 152        | 0x80000098                    | DMD     | Diamond                           |
-| 153        | 0x80000099                    | BTM     | Bytom                             |
-| 154        | 0x8000009a                    | BIO     | Biocoin                           |
-| 155        | 0x8000009b                    | XWCC    | Whitecoin Classic                 |
-| 156        | 0x8000009c                    | BTG     | Bitcoin Gold                      |
-| 157        | 0x8000009d                    | BTC2X   | Bitcoin 2x                        |
-| 158        | 0x8000009e                    | SSN     | SuperSkynet                       |
-| 159        | 0x8000009f                    | TOA     | TOACoin                           |
-| 160        | 0x800000a0                    | BTX     | Bitcore                           |
-| 161        | 0x800000a1                    | ACC     | Adcoin                            |
-| 162        | 0x800000a2                    | BCO     | Bridgecoin                        |
-| 163        | 0x800000a3                    | ELLA    | Ellaism                           |
-| 164        | 0x800000a4                    | PIRL    | Pirl                              |
-| 165        | 0x800000a5                    | XNO     | Nano                              |
-| 166        | 0x800000a6                    | VIVO    | Vivo                              |
-| 167        | 0x800000a7                    | FRST    | Firstcoin                         |
-| 168        | 0x800000a8                    | HNC     | Helleniccoin                      |
-| 169        | 0x800000a9                    | BUZZ    | BUZZ                              |
-| 170        | 0x800000aa                    | MBRS    | Ember                             |
-| 171        | 0x800000ab                    | HC      | Hcash                             |
-| 172        | 0x800000ac                    | HTML    | HTMLCOIN                          |
-| 173        | 0x800000ad                    | ODN     | Obsidian                          |
-| 174        | 0x800000ae                    | ONX     | OnixCoin                          |
-| 175        | 0x800000af                    | RVN     | Ravencoin                         |
-| 176        | 0x800000b0                    | GBX     | GoByte                            |
-| 177        | 0x800000b1                    | BTCZ    | BitcoinZ                          |
-| 178        | 0x800000b2                    | POA     | Poa                               |
-| 179        | 0x800000b3                    | NYC     | NewYorkCoin                       |
-| 180        | 0x800000b4                    | MXT     | MarteXcoin                        |
-| 181        | 0x800000b5                    | WC      | Wincoin                           |
-| 182        | 0x800000b6                    | MNX     | Minexcoin                         |
-| 183        | 0x800000b7                    | BTCP    | Bitcoin Private                   |
-| 184        | 0x800000b8                    | MUSIC   | Musicoin                          |
-| 185        | 0x800000b9                    | BCA     | Bitcoin Atom                      |
-| 186        | 0x800000ba                    | CRAVE   | Crave                             |
-| 187        | 0x800000bb                    | STAK    | STRAKS                            |
-| 188        | 0x800000bc                    | WBTC    | World Bitcoin                     |
-| 189        | 0x800000bd                    | LCH     | LiteCash                          |
-| 190        | 0x800000be                    | EXCL    | ExclusiveCoin                     |
-| 191        | 0x800000bf                    | LYNX    | Lynx                              |
-| 192        | 0x800000c0                    | LCC     | LitecoinCash                      |
-| 193        | 0x800000c1                    | XFE     | Feirm                             |
-| 194        | 0x800000c2                    | EOS     | EOS                               |
-| 195        | 0x800000c3                    | TRX     | Tron                              |
-| 196        | 0x800000c4                    | KOBO    | Kobocoin                          |
-| 197        | 0x800000c5                    | HUSH    | HUSH                              |
-| 198        | 0x800000c6                    | BAN     | Banano                            |
-| 199        | 0x800000c7                    | ETF     | ETF                               |
-| 200        | 0x800000c8                    | OMNI    | Omni                              |
-| 201        | 0x800000c9                    | BIFI    | BitcoinFile                       |
-| 202        | 0x800000ca                    | UFO     | Uniform Fiscal Object             |
-| 203        | 0x800000cb                    | CNMC    | Cryptonodes                       |
-| 204        | 0x800000cc                    | BCN     | Bytecoin                          |
-| 205        | 0x800000cd                    | RIN     | Ringo                             |
-| 206        | 0x800000ce                    | ATP     | Alaya                             |
-| 207        | 0x800000cf                    | EVT     | everiToken                        |
-| 208        | 0x800000d0                    | ATN     | ATN                               |
-| 209        | 0x800000d1                    | BIS     | Bismuth                           |
-| 210        | 0x800000d2                    | NEET    | NEETCOIN                          |
-| 211        | 0x800000d3                    | BOPO    | BopoChain                         |
-| 212        | 0x800000d4                    | OOT     | Utrum                             |
-| 213        | 0x800000d5                    | ALIAS   | Alias                             |
-| 214        | 0x800000d6                    | MONK    | Monkey Project                    |
-| 215        | 0x800000d7                    | BOXY    | BoxyCoin                          |
-| 216        | 0x800000d8                    | FLO     | Flo                               |
-| 217        | 0x800000d9                    | MEC     | Megacoin                          |
-| 218        | 0x800000da                    | BTDX    | BitCloud                          |
-| 219        | 0x800000db                    | XAX     | Artax                             |
-| 220        | 0x800000dc                    | ANON    | ANON                              |
-| 221        | 0x800000dd                    | LTZ     | LitecoinZ                         |
-| 222        | 0x800000de                    | BITG    | Bitcoin Green                     |
-| 223        | 0x800000df                    | ICP     | Internet Computer (DFINITY)       |
-| 224        | 0x800000e0                    | SMART   | Smartcash                         |
-| 225        | 0x800000e1                    | XUEZ    | XUEZ                              |
-| 226        | 0x800000e2                    | HLM     | Helium                            |
-| 227        | 0x800000e3                    | WEB     | Webchain                          |
-| 228        | 0x800000e4                    | ACM     | Actinium                          |
-| 229        | 0x800000e5                    | NOS     | NOS Stable Coins                  |
-| 230        | 0x800000e6                    | BITC    | BitCash                           |
-| 231        | 0x800000e7                    | HTH     | Help The Homeless Coin            |
-| 232        | 0x800000e8                    | TZC     | Trezarcoin                        |
-| 233        | 0x800000e9                    | VAR     | Varda                             |
-| 234        | 0x800000ea                    | IOV     | IOV                               |
-| 235        | 0x800000eb                    | FIO     | FIO                               |
-| 236        | 0x800000ec                    | BSV     | BitcoinSV                         |
-| 237        | 0x800000ed                    | DXN     | DEXON                             |
-| 238        | 0x800000ee                    | QRL     | Quantum Resistant Ledger          |
-| 239        | 0x800000ef                    | PCX     | ChainX                            |
-| 240        | 0x800000f0                    | LOKI    | Loki                              |
-| 241        | 0x800000f1                    |         | Imagewallet                       |
-| 242        | 0x800000f2                    | NIM     | Nimiq                             |
-| 243        | 0x800000f3                    | SOV     | Sovereign Coin                    |
-| 244        | 0x800000f4                    | JCT     | Jibital Coin                      |
-| 245        | 0x800000f5                    | SLP     | Simple Ledger Protocol            |
-| 246        | 0x800000f6                    | EWT     | Energy Web                        |
-| 247        | 0x800000f7                    | UC      | Ulord                             |
-| 248        | 0x800000f8                    | EXOS    | EXOS                              |
-| 249        | 0x800000f9                    | ECA     | Electra                           |
-| 250        | 0x800000fa                    | SOOM    | Soom                              |
-| 251        | 0x800000fb                    | XRD     | Redstone                          |
-| 252        | 0x800000fc                    | FREE    | FreeCoin                          |
-| 253        | 0x800000fd                    | NPW     | NewPowerCoin                      |
-| 254        | 0x800000fe                    | BST     | BlockStamp                        |
-| 255        | 0x800000ff                    |         | SmartHoldem                       |
-| 256        | 0x80000100                    | NANO    | Bitcoin Nano                      |
-| 257        | 0x80000101                    | BTCC    | Bitcoin Core                      |
-| 258        | 0x80000102                    |         | Zen Protocol                      |
-| 259        | 0x80000103                    | ZEST    | Zest                              |
-| 260        | 0x80000104                    | ABT     | ArcBlock                          |
-| 261        | 0x80000105                    | PION    | Pion                              |
-| 262        | 0x80000106                    | DT3     | DreamTeam3                        |
-| 263        | 0x80000107                    | ZBUX    | Zbux                              |
-| 264        | 0x80000108                    | KPL     | Kepler                            |
-| 265        | 0x80000109                    | TPAY    | TokenPay                          |
-| 266        | 0x8000010a                    | ZILLA   | ChainZilla                        |
-| 267        | 0x8000010b                    | ANK     | Anker                             |
-| 268        | 0x8000010c                    | BCC     | BCChain                           |
-| 269        | 0x8000010d                    | HPB     | HPB                               |
-| 270        | 0x8000010e                    | ONE     | ONE                               |
-| 271        | 0x8000010f                    | SBC     | SBC                               |
-| 272        | 0x80000110                    | IPC     | IPChain                           |
-| 273        | 0x80000111                    | DMTC    | Dominantchain                     |
-| 274        | 0x80000112                    | OGC     | Onegram                           |
-| 275        | 0x80000113                    | SHIT    | Shitcoin                          |
-| 276        | 0x80000114                    | ANDES   | Andescoin                         |
-| 277        | 0x80000115                    | AREPA   | Arepacoin                         |
-| 278        | 0x80000116                    | BOLI    | Bolivarcoin                       |
-| 279        | 0x80000117                    | RIL     | Rilcoin                           |
-| 280        | 0x80000118                    | HTR     | Hathor Network                    |
-| 281        | 0x80000119                    | ACME    | Accumulate                        |
-| 282        | 0x8000011a                    | BRAVO   | BRAVO                             |
-| 283        | 0x8000011b                    | ALGO    | Algorand                          |
-| 284        | 0x8000011c                    | BZX     | Bitcoinzero                       |
-| 285        | 0x8000011d                    | GXX     | GravityCoin                       |
-| 286        | 0x8000011e                    | HEAT    | HEAT                              |
-| 287        | 0x8000011f                    | XDN     | DigitalNote                       |
-| 288        | 0x80000120                    | FSN     | FUSION                            |
-| 289        | 0x80000121                    | CPC     | Capricoin                         |
-| 290        | 0x80000122                    | BOLD    | Bold                              |
-| 291        | 0x80000123                    | IOST    | IOST                              |
-| 292        | 0x80000124                    | TKEY    | Tkeycoin                          |
-| 293        | 0x80000125                    | USE     | Usechain                          |
-| 294        | 0x80000126                    | BCZ     | BitcoinCZ                         |
-| 295        | 0x80000127                    | IOC     | Iocoin                            |
-| 296        | 0x80000128                    | ASF     | Asofe                             |
-| 297        | 0x80000129                    | MASS    | MASS                              |
-| 298        | 0x8000012a                    | FAIR    | FairCoin                          |
-| 299        | 0x8000012b                    | NUKO    | Nekonium                          |
-| 300        | 0x8000012c                    | GNX     | Genaro Network                    |
-| 301        | 0x8000012d                    | DIVI    | Divi Project                      |
-| 302        | 0x8000012e                    | CMT     | Community                         |
-| 303        | 0x8000012f                    | EUNO    | EUNO                              |
-| 304        | 0x80000130                    | IOTX    | IoTeX                             |
-| 305        | 0x80000131                    | ONION   | DeepOnion                         |
-| 306        | 0x80000132                    | 8BIT    | 8Bit                              |
-| 307        | 0x80000133                    | ATC     | AToken Coin                       |
-| 308        | 0x80000134                    | BTS     | Bitshares                         |
-| 309        | 0x80000135                    | CKB     | Nervos CKB                        |
-| 310        | 0x80000136                    | UGAS    | Ultrain                           |
-| 311        | 0x80000137                    | ADS     | Adshares                          |
-| 312        | 0x80000138                    | ARA     | Aura                              |
-| 313        | 0x80000139                    | ZIL     | Zilliqa                           |
-| 314        | 0x8000013a                    | MOAC    | MOAC                              |
-| 315        | 0x8000013b                    | SWTC    | SWTC                              |
-| 316        | 0x8000013c                    | VNSC    | vnscoin                           |
-| 317        | 0x8000013d                    | PLUG    | Pl^g                              |
-| 318        | 0x8000013e                    | MAN     | Matrix AI Network                 |
-| 319        | 0x8000013f                    | ECC     | ECCoin                            |
-| 320        | 0x80000140                    | RPD     | Rapids                            |
-| 321        | 0x80000141                    | RAP     | Rapture                           |
-| 322        | 0x80000142                    | GARD    | Hashgard                          |
-| 323        | 0x80000143                    | ZER     | Zero                              |
-| 324        | 0x80000144                    | EBST    | eBoost                            |
-| 325        | 0x80000145                    | SHARD   | Shard                             |
-| 326        | 0x80000146                    | MRX     | Metrix Coin                       |
-| 327        | 0x80000147                    | CMM     | Commercium                        |
-| 328        | 0x80000148                    | BLOCK   | Blocknet                          |
-| 329        | 0x80000149                    | AUDAX   | AUDAX                             |
-| 330        | 0x8000014a                    | LUNA    | Terra                             |
-| 331        | 0x8000014b                    | ZPM     | zPrime                            |
-| 332        | 0x8000014c                    | KUVA    | Kuva Utility Note                 |
-| 333        | 0x8000014d                    | MEM     | MemCoin                           |
-| 334        | 0x8000014e                    | CS      | Credits                           |
-| 335        | 0x8000014f                    | SWIFT   | SwiftCash                         |
-| 336        | 0x80000150                    | FIX     | FIX                               |
-| 337        | 0x80000151                    | CPC     | CPChain                           |
-| 338        | 0x80000152                    | VGO     | VirtualGoodsToken                 |
-| 339        | 0x80000153                    | DVT     | DeVault                           |
-| 340        | 0x80000154                    | N8V     | N8VCoin                           |
-| 341        | 0x80000155                    | MTNS    | OmotenashiCoin                    |
-| 342        | 0x80000156                    | BLAST   | BLAST                             |
-| 343        | 0x80000157                    | DCT     | DECENT                            |
-| 344        | 0x80000158                    | AUX     | Auxilium                          |
-| 345        | 0x80000159                    | USDP    | USDP                              |
-| 346        | 0x8000015a                    | HTDF    | HTDF                              |
-| 347        | 0x8000015b                    | YEC     | Ycash                             |
-| 348        | 0x8000015c                    | QLC     | QLC Chain                         |
-| 349        | 0x8000015d                    | TEA     | Icetea Blockchain                 |
-| 350        | 0x8000015e                    | ARW     | ArrowChain                        |
-| 351        | 0x8000015f                    | MDM     | Medium                            |
-| 352        | 0x80000160                    | CYB     | Cybex                             |
-| 353        | 0x80000161                    | LTO     | LTO Network                       |
-| 354        | 0x80000162                    | DOT     | Polkadot                          |
-| 355        | 0x80000163                    | AEON    | Aeon                              |
-| 356        | 0x80000164                    | RES     | Resistance                        |
-| 357        | 0x80000165                    | AYA     | Aryacoin                          |
-| 358        | 0x80000166                    | DAPS    | Dapscoin                          |
-| 359        | 0x80000167                    | CSC     | CasinoCoin                        |
-| 360        | 0x80000168                    | VSYS    | V Systems                         |
-| 361        | 0x80000169                    | NOLLAR  | Nollar                            |
-| 362        | 0x8000016a                    | XNOS    | NOS                               |
-| 363        | 0x8000016b                    | CPU     | CPUchain                          |
-| 364        | 0x8000016c                    | LAMB    | Lambda Storage Chain              |
-| 365        | 0x8000016d                    | VCT     | ValueCyber                        |
-| 366        | 0x8000016e                    | CZR     | Canonchain                        |
-| 367        | 0x8000016f                    | ABBC    | ABBC                              |
-| 368        | 0x80000170                    | HET     | HET                               |
-| 369        | 0x80000171                    | XAS     | Asch                              |
-| 370        | 0x80000172                    | VDL     | Vidulum                           |
-| 371        | 0x80000173                    | MED     | MediBloc                          |
-| 372        | 0x80000174                    | ZVC     | ZVChain                           |
-| 373        | 0x80000175                    | VESTX   | Vestx                             |
-| 374        | 0x80000176                    | DBT     | DarkBit                           |
-| 375        | 0x80000177                    | SEOS    | SuperEOS                          |
-| 376        | 0x80000178                    | MXW     | Maxonrow                          |
-| 377        | 0x80000179                    | ZNZ     | ZENZO                             |
-| 378        | 0x8000017a                    | XCX     | XChain                            |
-| 379        | 0x8000017b                    | SOX     | SonicX                            |
-| 380        | 0x8000017c                    | NYZO    | Nyzo                              |
-| 381        | 0x8000017d                    | ULC     | ULCoin                            |
-| 382        | 0x8000017e                    | RYO     | Ryo Currency                      |
-| 383        | 0x8000017f                    | KAL     | Kaleidochain                      |
-| 384        | 0x80000180                    | XSN     | Stakenet                          |
-| 385        | 0x80000181                    | DOGEC   | DogeCash                          |
-| 386        | 0x80000182                    | BMV     | Bitcoin Matteo's Vision           |
-| 387        | 0x80000183                    | QBC     | Quebecoin                         |
-| 388        | 0x80000184                    | IMG     | ImageCoin                         |
-| 389        | 0x80000185                    | QOS     | QOS                               |
-| 390        | 0x80000186                    | PKT     | PKT                               |
-| 391        | 0x80000187                    | LHD     | LitecoinHD                        |
-| 392        | 0x80000188                    | CENNZ   | CENNZnet                          |
-| 393        | 0x80000189                    | HSN     | Hyper Speed Network               |
-| 394        | 0x8000018a                    | CRO     | Crypto Chain                      |
-| 395        | 0x8000018b                    | UMBRU   | Umbru                             |
-| 396        | 0x8000018c                    | EVER    | Everscale                         |
-| 397        | 0x8000018d                    | NEAR    | NEAR Protocol                     |
-| 398        | 0x8000018e                    | XPC     | XPChain                           |
-| 399        | 0x8000018f                    | ZOC     | 01coin                            |
-| 400        | 0x80000190                    | NIX     | NIX                               |
-| 401        | 0x80000191                    | UC      | Utopiacoin                        |
-| 402        | 0x80000192                    | GALI    | Galilel                           |
-| 403        | 0x80000193                    | OLT     | Oneledger                         |
-| 404        | 0x80000194                    | XBI     | XBI                               |
-| 405        | 0x80000195                    | DONU    | DONU                              |
-| 406        | 0x80000196                    | EARTHS  | Earths                            |
-| 407        | 0x80000197                    | HDD     | HDDCash                           |
-| 408        | 0x80000198                    | SUGAR   | Sugarchain                        |
-| 409        | 0x80000199                    | AILE    | AileCoin                          |
-| 410        | 0x8000019a                    | TENT    | TENT                              |
-| 411        | 0x8000019b                    | TAN     | Tangerine Network                 |
-| 412        | 0x8000019c                    | AIN     | AIN                               |
-| 413        | 0x8000019d                    | MSR     | Masari                            |
-| 414        | 0x8000019e                    | SUMO    | Sumokoin                          |
-| 415        | 0x8000019f                    | ETN     | Electroneum                       |
-| 416        | 0x800001a0                    | BYTZ    | BYTZ                              |
-| 417        | 0x800001a1                    | WOW     | Wownero                           |
-| 418        | 0x800001a2                    | XTNC    | XtendCash                         |
-| 419        | 0x800001a3                    | LTHN    | Lethean                           |
-| 420        | 0x800001a4                    | NODE    | NodeHost                          |
-| 421        | 0x800001a5                    | AGM     | Argoneum                          |
-| 422        | 0x800001a6                    | CCX     | Conceal Network                   |
-| 423        | 0x800001a7                    | TNET    | Title Network                     |
-| 424        | 0x800001a8                    | TELOS   | TelosCoin                         |
-| 425        | 0x800001a9                    | AION    | Aion                              |
-| 426        | 0x800001aa                    | BC      | Bitcoin Confidential              |
-| 427        | 0x800001ab                    | KTV     | KmushiCoin                        |
-| 428        | 0x800001ac                    | ZCR     | ZCore                             |
-| 429        | 0x800001ad                    | ERG     | Ergo                              |
-| 430        | 0x800001ae                    | PESO    | Criptopeso                        |
-| 431        | 0x800001af                    | BTC2    | Bitcoin 2                         |
-| 432        | 0x800001b0                    | XRPHD   | XRPHD                             |
-| 433        | 0x800001b1                    | WE      | WE Coin                           |
-| 434        | 0x800001b2                    | KSM     | Kusama                            |
-| 435        | 0x800001b3                    | PCN     | Peepcoin                          |
-| 436        | 0x800001b4                    | NCH     | NetCloth                          |
-| 437        | 0x800001b5                    | ICU     | CHIPO                             |
-| 438        | 0x800001b6                    | FNSA    | FINSCHIA                          |
-| 439        | 0x800001b7                    | DTP     | DeVault Token Protocol            |
-| 440        | 0x800001b8                    | BTCR    | Bitcoin Royale                    |
-| 441        | 0x800001b9                    | AERGO   | AERGO                             |
-| 442        | 0x800001ba                    | XTH     | Dothereum                         |
-| 443        | 0x800001bb                    | LV      | Lava                              |
-| 444        | 0x800001bc                    | PHR     | Phore                             |
-| 445        | 0x800001bd                    | VITAE   | Vitae                             |
-| 446        | 0x800001be                    | COCOS   | Cocos-BCX                         |
-| 447        | 0x800001bf                    | DIN     | Dinero                            |
-| 448        | 0x800001c0                    | SPL     | Simplicity                        |
-| 449        | 0x800001c1                    | YCE     | MYCE                              |
-| 450        | 0x800001c2                    | XLR     | Solaris                           |
-| 451        | 0x800001c3                    | KTS     | Klimatas                          |
-| 452        | 0x800001c4                    | DGLD    | DGLD                              |
-| 453        | 0x800001c5                    | XNS     | Insolar                           |
-| 454        | 0x800001c6                    | EM      | EMPOW                             |
-| 455        | 0x800001c7                    | SHN     | ShineBlocks                       |
-| 456        | 0x800001c8                    | SEELE   | Seele                             |
-| 457        | 0x800001c9                    | AE      | æternity                          |
-| 458        | 0x800001ca                    | ODX     | ObsidianX                         |
-| 459        | 0x800001cb                    | KAVA    | Kava                              |
-| 460        | 0x800001cc                    | GLEEC   | GLEEC                             |
-| 461        | 0x800001cd                    | FIL     | Filecoin                          |
-| 462        | 0x800001ce                    | RUTA    | Rutanio                           |
-| 463        | 0x800001cf                    | CSDT    | CSDT                              |
-| 464        | 0x800001d0                    | ETI     | EtherInc                          |
-| 465        | 0x800001d1                    | ZSLP    | Zclassic Simple Ledger Protocol   |
-| 466        | 0x800001d2                    | ERE     | EtherCore                         |
-| 467        | 0x800001d3                    | DX      | DxChain Token                     |
-| 468        | 0x800001d4                    | CPS     | Capricoin+                        |
-| 469        | 0x800001d5                    | BTH     | Bithereum                         |
-| 470        | 0x800001d6                    | MESG    | MESG                              |
-| 471        | 0x800001d7                    | FIMK    | FIMK                              |
-| 472        | 0x800001d8                    | AR      | Arweave                           |
-| 473        | 0x800001d9                    | OGO     | Origo                             |
-| 474        | 0x800001da                    | ROSE    | Oasis Network                     |
-| 475        | 0x800001db                    | BARE    | BARE Network                      |
-| 476        | 0x800001dc                    | GLEEC   | GleecBTC                          |
-| 477        | 0x800001dd                    | CLR     | Color Coin                        |
-| 478        | 0x800001de                    | RNG     | Ring                              |
-| 479        | 0x800001df                    | OLO     | Tool Global                       |
-| 480        | 0x800001e0                    | PEXA    | Pexa                              |
-| 481        | 0x800001e1                    | MOON    | Mooncoin                          |
-| 482        | 0x800001e2                    | OCEAN   | Ocean Protocol                    |
-| 483        | 0x800001e3                    | BNT     | Bluzelle Native                   |
-| 484        | 0x800001e4                    | AMO     | AMO Blockchain                    |
-| 485        | 0x800001e5                    | FCH     | FreeCash                          |
-| 486        | 0x800001e6                    | LAT     | PlatON                            |
-| 487        | 0x800001e7                    | COIN    | Bitcoin Bank                      |
-| 488        | 0x800001e8                    | VEO     | Amoveo                            |
-| 489        | 0x800001e9                    | CCA     | Counos Coin                       |
-| 490        | 0x800001ea                    | GFN     | Graphene                          |
-| 491        | 0x800001eb                    | BIP     | Minter Network                    |
-| 492        | 0x800001ec                    | KPG     | Kunpeng Network                   |
-| 493        | 0x800001ed                    | FIN     | FINL Chain                        |
-| 494        | 0x800001ee                    | BAND    | Band                              |
-| 495        | 0x800001ef                    | DROP    | Dropil                            |
-| 496        | 0x800001f0                    | BHT     | Bluehelix Chain                   |
-| 497        | 0x800001f1                    | LYRA    | Scrypta                           |
-| 498        | 0x800001f2                    | CS      | Credits                           |
-| 499        | 0x800001f3                    | RUPX    | Rupaya                            |
-| 500        | 0x800001f4                    | THETA   | Theta                             |
-| 501        | 0x800001f5                    | SOL     | Solana                            |
-| 502        | 0x800001f6                    | THT     | ThoughtAI                         |
-| 503        | 0x800001f7                    | CFX     | Conflux                           |
-| 504        | 0x800001f8                    | KUMA    | Kumacoin                          |
-| 505        | 0x800001f9                    | HASH    | Provenance                        |
-| 506        | 0x800001fa                    | CSPR    | Casper                            |
-| 507        | 0x800001fb                    | EARTH   | EARTH                             |
-| 508        | 0x800001fc                    | EGLD    | MultiversX                        |
-| 509        | 0x800001fd                    | CHI     | Xaya                              |
-| 510        | 0x800001fe                    | KOTO    | Koto                              |
-| 511        | 0x800001ff                    | OTC     | θ                                 |
-| 512        | 0x80000200                    | RXD     | Radiant                           |
-| 513        | 0x80000201                    | SEELEN  | Seele-N                           |
-| 514        | 0x80000202                    | AETH    | AETH                              |
-| 515        | 0x80000203                    | DNA     | Idena                             |
-| 516        | 0x80000204                    | VEE     | Virtual Economy Era               |
-| 517        | 0x80000205                    | SIERRA  | SierraCoin                        |
-| 518        | 0x80000206                    | LET     | Linkeye                           |
-| 519        | 0x80000207                    | BSC     | Bitcoin Smart Contract            |
-| 520        | 0x80000208                    | BTCV    | BitcoinVIP                        |
-| 521        | 0x80000209                    | ABA     | Dabacus                           |
-| 522        | 0x8000020a                    | SCC     | StakeCubeCoin                     |
-| 523        | 0x8000020b                    | EDG     | Edgeware                          |
-| 524        | 0x8000020c                    | AMS     | AmsterdamCoin                     |
-| 525        | 0x8000020d                    | GOSS    | GOSSIP Coin                       |
-| 526        | 0x8000020e                    | BU      | BUMO                              |
-| 527        | 0x8000020f                    | GRAM    | GRAM                              |
-| 528        | 0x80000210                    | YAP     | Yapstone                          |
-| 529        | 0x80000211                    | SCRT    | Secret Network                    |
-| 530        | 0x80000212                    | NOVO    | Novo                              |
-| 531        | 0x80000213                    | GHOST   | Ghost                             |
-| 532        | 0x80000214                    | HST     | HST                               |
-| 533        | 0x80000215                    | PRJ     | ProjectCoin                       |
-| 534        | 0x80000216                    | YOU     | YOUChain                          |
-| 535        | 0x80000217                    | XHV     | Haven Protocol                    |
-| 536        | 0x80000218                    | BYND    | Beyondcoin                        |
-| 537        | 0x80000219                    | JOYS    | Joys Digital                      |
-| 538        | 0x8000021a                    | VAL     | Valorbit                          |
-| 539        | 0x8000021b                    | FLOW    | Flow                              |
-| 540        | 0x8000021c                    | SMESH   | Spacemesh Coin                    |
-| 541        | 0x8000021d                    | SCDO    | SCDO                              |
-| 542        | 0x8000021e                    | IQS     | IQ-Cash                           |
-| 543        | 0x8000021f                    | BIND    | Compendia                         |
-| 544        | 0x80000220                    | COINEVO | Coinevo                           |
-| 545        | 0x80000221                    | SCRIBE  | Scribe                            |
-| 546        | 0x80000222                    | HYN     | Hyperion                          |
-| 547        | 0x80000223                    | BHP     | BHP                               |
-| 548        | 0x80000224                    | BBC     | BigBang Core                      |
-| 549        | 0x80000225                    | MKF     | MarketFinance                     |
-| 550        | 0x80000226                    | XDC     | XinFin                            |
-| 551        | 0x80000227                    | STR     | Straightedge                      |
-| 552        | 0x80000228                    | SUM     | Sumcoin                           |
-| 553        | 0x80000229                    | HBC     | HuobiChain                        |
-| 554        | 0x8000022a                    | ---     | reserved                          |
-| 555        | 0x8000022b                    | BCS     | Bitcoin Smart                     |
-| 556        | 0x8000022c                    | KTS     | Kratos                            |
-| 557        | 0x8000022d                    | LKR     | Lkrcoin                           |
-| 558        | 0x8000022e                    | TAO     | Tao                               |
-| 559        | 0x8000022f                    | XWC     | Whitecoin                         |
-| 560        | 0x80000230                    | DEAL    | DEAL                              |
-| 561        | 0x80000231                    | NTY     | Nexty                             |
-| 562        | 0x80000232                    | TOP     | TOP NetWork                       |
-| 563        | 0x80000233                    | ---     | reserved                          |
-| 564        | 0x80000234                    | AG      | Agoric                            |
-| 565        | 0x80000235                    | CICO    | Coinicles                         |
-| 566        | 0x80000236                    | IRIS    | Irisnet                           |
-| 567        | 0x80000237                    | NCG     | Nine Chronicles                   |
-| 568        | 0x80000238                    | LRG     | Large Coin                        |
-| 569        | 0x80000239                    | SERO    | Super Zero Protocol               |
-| 570        | 0x8000023a                    | BDX     | Beldex                            |
-| 571        | 0x8000023b                    | CCXX    | Counos X                          |
-| 572        | 0x8000023c                    | SLS     | Saluscoin                         |
-| 573        | 0x8000023d                    | SRM     | Serum                             |
-| 574        | 0x8000023e                    | ---     | reserved                          |
-| 575        | 0x8000023f                    | VIVT    | VIDT Datalink                     |
-| 576        | 0x80000240                    | BPS     | BitcoinPoS                        |
-| 577        | 0x80000241                    | NKN     | NKN                               |
-| 578        | 0x80000242                    | ICL     | ILCOIN                            |
-| 579        | 0x80000243                    | BONO    | Bonorum                           |
-| 580        | 0x80000244                    | PLC     | PLATINCOIN                        |
-| 581        | 0x80000245                    | DUN     | Dune                              |
-| 582        | 0x80000246                    | DMCH    | Darmacash                         |
-| 583        | 0x80000247                    | CTC     | Creditcoin                        |
-| 584        | 0x80000248                    | KELP    | Haidai Network                    |
-| 585        | 0x80000249                    | GBCR    | GoldBCR                           |
-| 586        | 0x8000024a                    | XDAG    | XDAG                              |
-| 587        | 0x8000024b                    | PRV     | Incognito Privacy                 |
-| 588        | 0x8000024c                    | SCAP    | SafeCapital                       |
-| 589        | 0x8000024d                    | TFUEL   | Theta Fuel                        |
-| 590        | 0x8000024e                    | GTM     | Gentarium                         |
-| 591        | 0x8000024f                    | RNL     | RentalChain                       |
-| 592        | 0x80000250                    | GRIN    | Grin                              |
-| 593        | 0x80000251                    | MWC     | MimbleWimbleCoin                  |
-| 594        | 0x80000252                    | DOCK    | Dock                              |
-| 595        | 0x80000253                    | POLYX   | Polymesh                          |
-| 596        | 0x80000254                    | DIVER   | Divergenti                        |
-| 597        | 0x80000255                    | XEP     | Electra Protocol                  |
-| 598        | 0x80000256                    | APN     | Apron                             |
-| 599        | 0x80000257                    | TFC     | Turbo File Coin                   |
-| 600        | 0x80000258                    | UTE     | Unit-e                            |
-| 601        | 0x80000259                    | MTC     | Metacoin                          |
-| 602        | 0x8000025a                    | NC      | NobodyCash                        |
-| 603        | 0x8000025b                    | XINY    | Xinyuehu                          |
-| 604        | 0x8000025c                    | DYN     | Dynamo                            |
-| 605        | 0x8000025d                    | BUFS    | Buffer                            |
-| 606        | 0x8000025e                    | STOS    | Stratos                           |
-| 607        | 0x8000025f                    | TON     | TON                               |
-| 608        | 0x80000260                    | TAFT    | TAFT                              |
-| 609        | 0x80000261                    | HYDRA   | HYDRA                             |
-| 610        | 0x80000262                    | NOR     | Noir                              |
-| 611        | 0x80000263                    |         | Manta Network Private Asset       |
-| 612        | 0x80000264                    |         | Calamari Network Private Asset    |
-| 613        | 0x80000265                    | WCN     | Widecoin                          |
-| 614        | 0x80000266                    | OPT     | Optimistic Ethereum               |
-| 615        | 0x80000267                    | PSWAP   | PolkaSwap                         |
-| 616        | 0x80000268                    | VAL     | Validator                         |
-| 617        | 0x80000269                    | XOR     | Sora                              |
-| 618        | 0x8000026a                    | SSP     | SmartShare                        |
-| 619        | 0x8000026b                    | DEI     | DeimosX                           |
-| 620        | 0x8000026c                    | ---     | reserved                          |
-| 621        | 0x8000026d                    | ZERO    | Singularity                       |
-| 622        | 0x8000026e                    | ALPHA   | AlphaDAO                          |
-| 623        | 0x8000026f                    | BDECO   | BDCashProtocol Ecosystem          |
-| 624        | 0x80000270                    | NOBL    | Nobility                          |
-| 625        | 0x80000271                    | EAST    | Eastcoin                          |
-| 626        | 0x80000272                    | KDA     | Kadena                            |
-| 627        | 0x80000273                    | SOUL    | Phantasma                         |
-| 628        | 0x80000274                    | LORE    | Gitopia                           |
-| 629        | 0x80000275                    | FNR     | Fincor                            |
-| 630        | 0x80000276                    | NEXUS   | Nexus                             |
-| 631        | 0x80000277                    | QTZ     | Quartz                            |
-| 632        | 0x80000278                    | MAS     | Massa                             |
-| 633        | 0x80000279                    | CALL    | Callchain                         |
-| 634        | 0x8000027a                    | VAL     | Validity                          |
-| 635        | 0x8000027b                    | POKT    | Pocket Network                    |
-| 636        | 0x8000027c                    | EMIT    | EMIT                              |
-| 637        | 0x8000027d                    | APTOS   | Aptos                             |
-| 638        | 0x8000027e                    | ADON    | ADON                              |
-| 639        | 0x8000027f                    | BTSG    | BitSong                           |
-| 640        | 0x80000280                    | LFC     | Leofcoin                          |
-| 641        | 0x80000281                    | KCS     | KuCoin Shares                     |
-| 642        | 0x80000282                    | KCC     | KuCoin Community Chain            |
-| 643        | 0x80000283                    | AZERO   | Aleph Zero                        |
-| 644        | 0x80000284                    | TREE    | Tree                              |
-| 645        | 0x80000285                    | LX      | Lynx                              |
-| 646        | 0x80000286                    | XLN     | Lunarium                          |
-| 647        | 0x80000287                    | CIC     | CIC Chain                         |
-| 648        | 0x80000288                    | ZRB     | Zarb                              |
-| 649        | 0x80000289                    | ---     | reserved                          |
-| 650        | 0x8000028a                    | UCO     | Archethic                         |
-| 651        | 0x8000028b                    | SFX     | Safex Cash                        |
-| 652        | 0x8000028c                    | SFT     | Safex Token                       |
-| 653        | 0x8000028d                    | WSFX    | Wrapped Safex Cash                |
-| 654        | 0x8000028e                    | USDG    | US Digital Gold                   |
-| 655        | 0x8000028f                    | WMP     | WAMP                              |
-| 656        | 0x80000290                    | EKTA    | Ekta                              |
-| 657        | 0x80000291                    | YDA     | YadaCoin                          |
-| 658        | 0x80000292                    | WHIVE   | Whive                             |
-| 659        | 0x80000293                    | KOIN    | Koinos                            |
-| 660        | 0x80000294                    | PIRATE  | PirateCash                        |
-| 661        | 0x80000295                    | UNQ     | Unique                            |
-| 662        | 0x80000296                    | ULM     | UltonSmartchain                   |
-| 663        | 0x80000297                    | SFRX    | EtherGem Sapphire                 |
-| 664        | 0x80000298                    | BSTY    | GlobalBoost-Y                     |
-| 665        | 0x80000299                    | IMP     | Impact Protocol                   |
-| 666        | 0x8000029a                    | ACT     | Achain                            |
-| 667        | 0x8000029b                    | PRKL    | Perkle                            |
-| 668        | 0x8000029c                    | SSC     | SelfSell                          |
-| 669        | 0x8000029d                    | GC      | GateChain                         |
-| 670        | 0x8000029e                    | PLGR    | Pledger                           |
-| 671        | 0x8000029f                    | MPLGR   | Pledger                           |
-| 672        | 0x800002a0                    | KNOX    | Knox                              |
-| 673        | 0x800002a1                    | ZED     | ZED                               |
-| 674        | 0x800002a2                    | CNDL    | Candle                            |
-| 675        | 0x800002a3                    | WLKR    | Walker Crypto Innovation Index    |
-| 676        | 0x800002a4                    | WLKRR   | Walker                            |
-| 677        | 0x800002a5                    | YUNGE   | Yunge                             |
-| 678        | 0x800002a6                    | Voken   | Voken                             |
-| 679        | 0x800002a7                    | APL     | Apollo                            |
-| 680        | 0x800002a8                    | Evrynet | Evrynet                           |
-| 681        | 0x800002a9                    | NENG    | Nengcoin                          |
-| 682        | 0x800002aa                    | CHTA    | Cheetahcoin                       |
-| 683        | 0x800002ab                    | ALEO    | Aleo Network                      |
-| 684        | 0x800002ac                    | HMS     | Hemis                             |
-| 685        | 0x800002ad                    | OAS     | Oasys                             |
-| 686        | 0x800002ae                    | KAR     | Karura Network                    |
-| 687        | 0x800002af                    | FLON    | FullOn Network                    |
-| 688        | 0x800002b0                    | CET     | CoinEx Chain                      |
-| 689        | 0x800002b1                    | XLINK   | XLink Chain                       |
-| 690        | 0x800002b2                    | KLV     | KleverChain                       |
-| 691        | 0x800002b3                    | TNT     | Tangle                            |
-| 692        | 0x800002b4                    | GTG     | Gotigin                           |
-| 693        | 0x800002b5                    | NET     | RealityNet                        |
-| 694        | 0x800002b6                    | VTBC    | VTB Community                     |
-| 695        | 0x800002b7                    | DIONE   | Odyssey Chain                     |
-| 696        | 0x800002b8                    | LUM     | Lumos                             |
-| 697        | 0x800002b9                    | AVA     | Avalon                            |
-| 698        | 0x800002ba                    | VEIL    | Veil                              |
-| 699        | 0x800002bb                    | GTB     | GotaBit                           |
-| 700        | 0x800002bc                    | XDAI    | xDai                              |
-| 701        | 0x800002bd                    | COM     | Commercio                         |
-| 702        | 0x800002be                    | CCC     | Commercio Cash Credit             |
-| 703        | 0x800002bf                    | SNR     | Sonr                              |
-| 704        | 0x800002c0                    | RAQ     | Ra Quantum                        |
-| 705        | 0x800002c1                    | PEG     | Pegasus Token                     |
-| 706        | 0x800002c2                    | LKG     | Lionking                          |
-| 707        | 0x800002c3                    | MCOIN   | Moneta Coin                       |
-| 708        | 0x800002c4                    | ---     | reserved                          |
-| 709        | 0x800002c5                    | AVAIL   | Avail                             |
-| 710        | 0x800002c6                    | FURY    | Highbury                          |
-| 711        | 0x800002c7                    | CHC     | Chaincoin                         |
-| 712        | 0x800002c8                    | SERF    | Serfnet                           |
-| 713        | 0x800002c9                    | XTL     | Katal Chain                       |
-| 714        | 0x800002ca                    | BNB     | Binance                           |
-| 715        | 0x800002cb                    | SIN     | Sinovate                          |
-| 716        | 0x800002cc                    | DLN     | Delion                            |
-| 717        | 0x800002cd                    | BONTE   | Bontecoin                         |
-| 718        | 0x800002ce                    | PEER    | Peer                              |
-| 719        | 0x800002cf                    | ZET     | Zetacoin                          |
-| 720        | 0x800002d0                    | ABY     | Artbyte                           |
-| 721        | 0x800002d1                    | PGX     | Mirai Chain                       |
-| 722        | 0x800002d2                    | IL8P    | InfiniLooP                        |
-| 723        | 0x800002d3                    | VOI     | Voi                               |
-| 724        | 0x800002d4                    | XVC     | Vanillacash                       |
-| 725        | 0x800002d5                    | MCX     | MultiCash                         |
-| 726        | 0x800002d6                    | TARA    | Taraxa                            |
-| 727        | 0x800002d7                    | BLU     | BluCrates                         |
-| 728        | 0x800002d8                    | BFC     | BFC                               |
-| 729        | 0x800002d9                    | DCC     | DecentraCast                      |
-| 730        | 0x800002da                    | HEALIOS | Tenacity                          |
-| 731        | 0x800002db                    | BMK     | Bitmark                           |
-| 732        | 0x800002dc                    | FUGA    | Fuga token                        |
-| 733        | 0x800002dd                    | TBC     | TBChat                            |
-| 734        | 0x800002de                    | DENTX   | DENTNet                           |
-| 735        | 0x800002df                    | NBY     | Neobytes                          |
-| 736        | 0x800002e0                    | BABY    | BABY                              |
-| 737        | 0x800002e1                    | ATOP    | Financial Blockchain              |
-| 738        | 0x800002e2                    | BTE     | Bitweb                            |
-| 739        | 0x800002e3                    | DPC     | Dpowcoin (DualPowCoin)            |
-| 740        | 0x800002e4                    | MDC     | MyDataCoin                        |
-| 741        | 0x800002e5                    | RIV     | Rigvid                            |
-| 742        | 0x800002e6                    | LTO     | LTO Network                       |
-| 743        | 0x800002e7                    | LKY     | LuckyCoin                         |
-| 744        | 0x800002e8                    | DUSK    | Dusk                              |
-| 745        | 0x800002e9                    | DIMI    | DiminutiveCoin                    |
-| 746        | 0x800002ea                    | PLM     | Palladium                         |
-| 747        | 0x800002eb                    | CFG     | Centrifuge                        |
-| 748        | 0x800002ec                    |         |
-| 749        | 0x800002ed                    |         |
-| 750        | 0x800002ee                    | XPRT    | Persistence                       |
-| 751        | 0x800002ef                    |         |
-| 752        | 0x800002f0                    |         |
-| 753        | 0x800002f1                    |         | Age X25519 Encryption             |
-| 754        | 0x800002f2                    |         | Age NIST Encryption               |
-| 755        | 0x800002f3                    |         |
-| 756        | 0x800002f4                    |         |
-| 757        | 0x800002f5                    | HONEY   | HoneyWood                         |
-| 758        | 0x800002f6                    | XDD     | XDDCoin                           |
-| 759        | 0x800002f7                    | TBI     | TBicloud                          |
-| 760        | 0x800002f8                    | FGC     | Figcoin                           |
-| 761        | 0x800002f9                    |         |
-| 762        | 0x800002fa                    | BELLS   | Bellscoin                         |
-| 763        | 0x800002fb                    |         |
-| 764        | 0x800002fc                    |         |
-| 765        | 0x800002fd                    | TGN     | Tagion                            |
-| 766        | 0x800002fe                    |         |
-| 767        | 0x800002ff                    | LLD     | Liberland                         |
-| 768        | 0x80000300                    | BALLZ   | Ballzcoin                         |
-| 769        | 0x80000301                    |         |
-| 770        | 0x80000302                    | COSA    | Cosanta                           |
-| 771        | 0x80000303                    | BR      | BR                                |
-| 772        | 0x80000304                    |         |
-| 773        | 0x80000305                    | CSB     | CosmoBliss                        |
-| 774        | 0x80000306                    |         |
-| 775        | 0x80000307                    | PLSR    | Pulsar Coin                       |
-| 776        | 0x80000308                    | KEY     | Keymaker Coin                     |
-| 777        | 0x80000309                    | BTW     | Bitcoin World                     |
-| 778        | 0x8000030a                    |         |
-| 779        | 0x8000030b                    | UCHAIN  | UCHAIN                            |
-| 780        | 0x8000030c                    | PLCUC   | PLC Ultima Classic                |
-| 781        | 0x8000030d                    | PLCUX   | PLC Ultima X                      |
-| 782        | 0x8000030e                    | PLCU    | PLC Ultima                        |
-| 783        | 0x8000030f                    | SMARTBC | SMART Blockchain                  |
-| 784        | 0x80000310                    | SUI     | Sui                               |
-| 785        | 0x80000311                    | ULTIMA  | ULTIMA                            |
-| 786        | 0x80000312                    | UIDD    | UIDD                              |
-| 787        | 0x80000313                    | ACA     | Acala                             |
-| 788        | 0x80000314                    | BNC     | Bifrost                           |
-| 789        | 0x80000315                    | TAU     | Lamden                            |
-| 790        | 0x80000316                    | LKY     | Luckycoin                         |
-| 791        | 0x80000317                    | SOMA    | Soma                              |
-| 792        | 0x80000318                    |         |
-| 793        | 0x80000319                    |         |
-| 794        | 0x8000031a                    | INTR    | Interlay                          |
-| 795        | 0x8000031b                    | KINT    | Kintsugi                          |
-| 796        | 0x8000031c                    |         |
-| 797        | 0x8000031d                    | MVRX    | Muvor ERP                         |
-| 798        | 0x8000031e                    |         |
-| 799        | 0x8000031f                    | PDEX    | Polkadex                          |
-| 800        | 0x80000320                    | BEET    | Beetle Coin                       |
-| 801        | 0x80000321                    | DST     | DSTRA                             |
-| 802        | 0x80000322                    | CY      | Cyberyen                          |
-| 803        | 0x80000323                    | RYME    | Ryme Network                      |
-| 804        | 0x80000324                    | ZKS     | zkSync                            |
-| 805        | 0x80000325                    | SCASH   | Scash                             |
-| 806        | 0x80000326                    |         |
-| 807        | 0x80000327                    |         |
-| 808        | 0x80000328                    | QVT     | Qvolta                            |
-| 809        | 0x80000329                    | SDN     | Shiden Network                    |
-| 810        | 0x8000032a                    | ASTR    | Astar Network                     |
-| 811        | 0x8000032b                    | ---     | reserved                          |
-| 812        | 0x8000032c                    |         |
-| 813        | 0x8000032d                    | MEER    | Qitmeer                           |
-| 814        | 0x8000032e                    |         |
-| 815        | 0x8000032f                    | FACT    | ImFACT                            |
-| 816        | 0x80000330                    | FSC     | FSC                               |
-| 817        | 0x80000331                    |         |
-| 818        | 0x80000332                    | VET     | VeChain Token                     |
-| 819        | 0x80000333                    | REEF    | Reef                              |
-| 820        | 0x80000334                    | CLO     | Callisto                          |
-| 821        | 0x80000335                    |         |
-| 822        | 0x80000336                    | BDB     | BigchainDB                        |
-| 823        | 0x80000337                    | TBL     | TBLINK                            |
-| 824        | 0x80000338                    | RBNT    | Redbelly Network                  |
-| 825        | 0x80000339                    |         |
-| 826        | 0x8000033a                    | YBC     | YBChain                           |
-| 827        | 0x8000033b                    | ACE     | Endurance                         |
-| 828        | 0x8000033c                    | CCN     | ComputeCoin                       |
-| 829        | 0x8000033d                    | BBA     | BBACHAIN                          |
-| 830        | 0x8000033e                    |         |
-| 831        | 0x8000033f                    | CRUZ    | cruzbit                           |
-| 832        | 0x80000340                    | SAPP    | Sapphire                          |
-| 833        | 0x80000341                    | 777     | Jackpot                           |
-| 834        | 0x80000342                    | KYAN    | Kyanite                           |
-| 835        | 0x80000343                    | AZR     | Azzure                            |
-| 836        | 0x80000344                    | CFL     | CryptoFlow                        |
-| 837        | 0x80000345                    | DASHD   | Dash Diamond                      |
-| 838        | 0x80000346                    | TRTT    | Trittium                          |
-| 839        | 0x80000347                    | UCR     | Ultra Clear                       |
-| 840        | 0x80000348                    | PNY     | Peony                             |
-| 841        | 0x80000349                    | BECN    | Beacon                            |
-| 842        | 0x8000034a                    | MONK    | Monk                              |
-| 843        | 0x8000034b                    | SAGA    | CryptoSaga                        |
-| 844        | 0x8000034c                    | SUV     | Suvereno                          |
-| 845        | 0x8000034d                    | ESK     | EskaCoin                          |
-| 846        | 0x8000034e                    | OWO     | OneWorld Coin                     |
-| 847        | 0x8000034f                    | PEPS    | PEPS Coin                         |
-| 848        | 0x80000350                    | BIR     | Birake                            |
-| 849        | 0x80000351                    | MOBIC   | MobilityCoin                      |
-| 850        | 0x80000352                    | FLS     | Flits                             |
-| 851        | 0x80000353                    | FRECO   | Freco                             |
-| 852        | 0x80000354                    | DSM     | Desmos                            |
-| 853        | 0x80000355                    | PRCY    | PRCY Coin                         |
-| 854        | 0x80000356                    |         |
-| 855        | 0x80000357                    |         |
-| 856        | 0x80000358                    | TB      | TBCoin                            |
-| 857        | 0x80000359                    |         |
-| 858        | 0x8000035a                    | HVH     | HAVAH                             |
-| 859        | 0x8000035b                    |         |
-| 860        | 0x8000035c                    | XBIT    | XBIT Coin                         |
-| 861        | 0x8000035d                    |         |
-| 862        | 0x8000035e                    |         |
-| 863        | 0x8000035f                    |         |
-| 864        | 0x80000360                    | CVM     | Convex                            |
-| 865        | 0x80000361                    |         |
-| 866        | 0x80000362                    | MOB     | MobileCoin                        |
-| 867        | 0x80000363                    |         |
-| 868        | 0x80000364                    | IF      | Infinitefuture                    |
-| 869        | 0x80000365                    | TXFLOW  | TxFlow                            |
-| 870        | 0x80000366                    |         |
-| 871        | 0x80000367                    |         |
-| 872        | 0x80000368                    |         |
-| 873        | 0x80000369                    | QUORUM  | Quorum                            |
-| 874        | 0x8000036a                    |         |
-| 875        | 0x8000036b                    |         |
-| 876        | 0x8000036c                    |         |
-| 877        | 0x8000036d                    | NAM     | Namada                            |
-| 878        | 0x8000036e                    | SCR     | Scorum Network                    |
-| 879        | 0x8000036f                    |         |
-| 880        | 0x80000370                    | LUM     | Lum Network                       |
-| 881        | 0x80000371                    | AEGS    | Aegisum                           |
-| 882        | 0x80000372                    |         |
-| 883        | 0x80000373                    | ZBC     | ZooBC                             |
-| 884        | 0x80000374                    |         |
-| 885        | 0x80000375                    | XCN     | XCoin                             |
-| 886        | 0x80000376                    | ADF     | AD Token                          |
-| 887        | 0x80000377                    |         |
-| 888        | 0x80000378                    | NEO     | NEO                               |
-| 889        | 0x80000379                    | TOMO    | TOMO                              |
-| 890        | 0x8000037a                    | XSEL    | Seln                              |
-| 891        | 0x8000037b                    |         |
-| 892        | 0x8000037c                    |         |
-| 893        | 0x8000037d                    |         |
-| 894        | 0x8000037e                    |         |
-| 895        | 0x8000037f                    |         |
-| 896        | 0x80000380                    | LKSC    | LKSCoin                           |
-| 897        | 0x80000381                    |         |
-| 898        | 0x80000382                    | AS      | Assetchain                        |
-| 899        | 0x80000383                    | XEC     | eCash                             |
-| 900        | 0x80000384                    | LMO     | Lumeneo                           |
-| 901        | 0x80000385                    | NXT     | NxtMeta                           |
-| 902        | 0x80000386                    |         |
-| 903        | 0x80000387                    | EGN     | EGAHN Intelligence Network        |
-| 904        | 0x80000388                    | HNT     | Helium                            |
-| 905        | 0x80000389                    |         |
-| 906        | 0x8000038a                    | XPX     | Sirius                            |
-| 907        | 0x8000038b                    | FIS     | StaFi                             |
-| 908        | 0x8000038c                    |         |
-| 909        | 0x8000038d                    | SGE     | Saage                             |
-| 910        | 0x8000038e                    |         |
-| 911        | 0x8000038f                    | GERT    | Gert                              |
-| 912        | 0x80000390                    |         |
-| 913        | 0x80000391                    | VARA    | Vara Network                      |
-| 914        | 0x80000392                    |         |
-| 915        | 0x80000393                    |         |
-| 916        | 0x80000394                    | META    | Metadium                          |
-| 917        | 0x80000395                    | FRA     | Findora                           |
-| 918        | 0x80000396                    |         |
-| 919        | 0x80000397                    | CCD     | Concordium                        |
-| 920        | 0x80000398                    |         |
-| 921        | 0x80000399                    | AVN     | Avian Network                     |
-| 922        | 0x8000039a                    |         |
-| 923        | 0x8000039b                    |         |
-| 924        | 0x8000039c                    |         |
-| 925        | 0x8000039d                    | DIP     | Dipper Network                    |
-| 926        | 0x8000039e                    |         |
-| 927        | 0x8000039f                    |         |
-| 928        | 0x800003a0                    | GHM     | HermitMatrixNetwork               |
-| 929        | 0x800003a1                    |         |
-| 930        | 0x800003a2                    |         |
-| 931        | 0x800003a3                    | RUNE    | THORChain (RUNE)                  |
-| 932        | 0x800003a4                    |         |
-| 933        | 0x800003a5                    |         |
-| 934        | 0x800003a6                    |         |
-| 935        | 0x800003a7                    |         |
-| 936        | 0x800003a8                    |         |
-| 937        | 0x800003a9                    |         |
-| 938        | 0x800003aa                    | MGO     | Mango Network                     |
-| 939        | 0x800003ab                    | AB      | Argot Protocol                    |
-| 940        | 0x800003ac                    |         |
-| 941        | 0x800003ad                    | ---     | reserved                          |
-| 942        | 0x800003ae                    | KCN     | Kylacoin                          |
-| 943        | 0x800003af                    | LCN     | Lyncoin                           |
-| 944        | 0x800003b0                    |         |
-| 945        | 0x800003b1                    | UNLOCK  | Jasiri protocol                   |
-| 946        | 0x800003b2                    |         |
-| 947        | 0x800003b3                    |         |
-| 948        | 0x800003b4                    |         |
-| 949        | 0x800003b5                    |         |
-| 950        | 0x800003b6                    | CNDT    | Conduct Protocol                  |
-| 951        | 0x800003b7                    |         |
-| 952        | 0x800003b8                    |         |
-| 953        | 0x800003b9                    |         |
-| 954        | 0x800003ba                    |         |
-| 955        | 0x800003bb                    | LTP     | LifetionCoin                      |
-| 956        | 0x800003bc                    |         |
-| 957        | 0x800003bd                    |         |
-| 958        | 0x800003be                    |         | KickSoccer                        |
-| 959        | 0x800003bf                    |         |
-| 960        | 0x800003c0                    | VKAX    | Vkax                              |
-| 961        | 0x800003c1                    |         |
-| 962        | 0x800003c2                    |         |
-| 963        | 0x800003c3                    | SYL     | OpenSY                            |
-| 964        | 0x800003c4                    |         |
-| 965        | 0x800003c5                    | ATLA    | Atleta Network                    |
-| 966        | 0x800003c6                    | MATIC   | Matic                             |
-| 967        | 0x800003c7                    |         |
-| 968        | 0x800003c8                    | UNW     | UNW                               |
-| 969        | 0x800003c9                    | QI      | Quai Network                      |
-| 970        | 0x800003ca                    | TWINS   | TWINS                             |
-| 971        | 0x800003cb                    |         |
-| 972        | 0x800003cc                    |         |
-| 973        | 0x800003cd                    |         |
-| 974        | 0x800003ce                    |         |
-| 975        | 0x800003cf                    |         | TrustNet                          |
-| 976        | 0x800003d0                    |         |
-| 977        | 0x800003d1                    | TLOS    | Telos                             |
-| 978        | 0x800003d2                    |         |
-| 979        | 0x800003d3                    |         |
-| 980        | 0x800003d4                    |         |
-| 981        | 0x800003d5                    | TAFECO  | Taf ECO Chain                     |
-| 982        | 0x800003d6                    |         |
-| 983        | 0x800003d7                    |         |
-| 984        | 0x800003d8                    |         |
-| 985        | 0x800003d9                    | AU      | Autonomy                          |
-| 986        | 0x800003da                    |         |
-| 987        | 0x800003db                    | VCG     | VipCoin                           |
-| 988        | 0x800003dc                    | XAZAB   | Xazab core                        |
-| 989        | 0x800003dd                    | AIOZ    | AIOZ                              |
-| 990        | 0x800003de                    | CORE    | TX                                |
-| 991        | 0x800003df                    | PEC     | Phoenix                           |
-| 992        | 0x800003e0                    | UNT     | Unit                              |
-| 993        | 0x800003e1                    | XRB     | X Currency                        |
-| 994        | 0x800003e2                    | QUAI    | Quai Network                      |
-| 995        | 0x800003e3                    | CAPS    | Ternoa                            |
-| 996        | 0x800003e4                    | OKT     | OKChain Token                     |
-| 997        | 0x800003e5                    | SUM     | Solidum                           |
-| 998        | 0x800003e6                    | LBTC    | Lightning Bitcoin                 |
-| 999        | 0x800003e7                    | BCD     | Bitcoin Diamond                   |
-| 1000       | 0x800003e8                    | BTN     | Bitcoin New                       |
-| 1001       | 0x800003e9                    | TT      | ThunderCore                       |
-| 1002       | 0x800003ea                    | BKT     | BanKitt                           |
-| 1003       | 0x800003eb                    | NODL    | Nodle                             |
-| 1004       | 0x800003ec                    | PCOIN   | PCOIN                             |
-| 1005       | 0x800003ed                    | TAO     | Bittensor                         |
-| 1006       | 0x800003ee                    | HSK     | HashKey Chain                     |
-| 1007       | 0x800003ef                    | FTM     | Fantom                            |
-| 1008       | 0x800003f0                    | RPG     | RPG                               |
-| 1009       | 0x800003f1                    | LAKE    | iconLake                          |
-| 1010       | 0x800003f2                    | HT      | Huobi ECO Chain                   |
-| 1011       | 0x800003f3                    | ELV     | Eluvio                            |
-| 1012       | 0x800003f4                    | JOC     | Japan Open Chain                  |
-| 1013       | 0x800003f5                    | BIC     | Beincrypto                        |
-| 1014       | 0x800003f6                    | JOY     | Joystream                         |
-| 1015       | 0x800003f7                    | ZCX     | ZEN Exchange Token                |
-| 1016       | 0x800003f8                    | ---     | reserved                          |
-| 1017       | 0x800003f9                    | ZTC     | Zenchain                          |
-| 1018       | 0x800003fa                    | ZANO    | Zano                              |
-| 1019       | 0x800003fb                    | GEEQ    | Geeq                              |
-| 1020       | 0x800003fc                    | EVC     | Evrice                            |
-| 1021       | 0x800003fd                    | PKOIN   | Pocketcoin                        |
-| 1022       | 0x800003fe                    | XRD     | Radix DLT                         |
-| 1023       | 0x800003ff                    | ONE     | HARMONY-ONE (Legacy)              |
-| 1024       | 0x80000400                    | ONT     | Ontology                          |
-| 1025       | 0x80000401                    | CZZ     | Classzz                           |
-| 1026       | 0x80000402                    | KEX     | Kira Exchange Token               |
-| 1027       | 0x80000403                    | MCM     | Mochimo                           |
-| 1028       | 0x80000404                    | PLS     | Pulse Coin                        |
-| 1032       | 0x80000408                    | BTCR    | BTCR                              |
-| 1042       | 0x80000412                    | MFID    | Moonfish ID                       |
-| 1100       | 0x8000044c                    | CROSS   | Cross Chain                       |
-| 1110       | 0x80000456                    | ZRA     | ZERA                              |
-| 1111       | 0x80000457                    | BBC     | Big Bitcoin                       |
-| 1116       | 0x8000045c                    | CORE    | Core                              |
-| 1120       | 0x80000460                    | RISE    | RISE                              |
-| 1122       | 0x80000462                    | CMT     | CyberMiles Token                  |
-| 1128       | 0x80000468                    | ETSC    | Ethereum Social                   |
-| 1129       | 0x80000469                    | DFI     | DeFiChain                         |
-| 1130       | 0x8000046a                    | DFI     | DeFiChain EVM Network             |
-| 1134       | 0x8000046e                    | MESH    | StateMesh                         |
-| 1137       | 0x80000471                    | $DAG    | Constellation Labs                |
-| 1145       | 0x80000479                    | CDY     | Bitcoin Candy                     |
-| 1155       | 0x80000483                    | ENJ     | Enjin Coin                        |
-| 1170       | 0x80000492                    | HOO     | Hoo Smart Chain                   |
-| 1200       | 0x800004b0                    | GNK     | Gonka                             |
-| 1234       | 0x800004d2                    | ALPH    | Alephium                          |
-| 1236       | 0x800004d4                    |         | Masca                             |
-| 1237       | 0x800004d5                    |         | Nostr                             |
-| 1280       | 0x80000500                    |         | Kudos Setler                      |
-| 1284       | 0x80000504                    | GLMR    | Moonbeam                          |
-| 1285       | 0x80000505                    | MOVR    | Moonriver                         |
-| 1286       | 0x80000506                    | DSG     | Dessage Social Protocol           |
-| 1298       | 0x80000512                    | WPC     | Wpc                               |
-| 1308       | 0x8000051c                    | WEI     | WEI                               |
-| 1312       | 0x80000520                    | BITS    | Entropy                           |
-| 1313       | 0x80000521                    | GAEL    | Gaelium                           |
-| 1337       | 0x80000539                    | DFC     | Defcoin                           |
-| 1338       | 0x8000053a                    | IRON    | Iron Fish                         |
-| 1339       | 0x8000053b                    | WNSD    | Winsdet                           |
-| 1348       | 0x80000544                    | ISLM    | IslamicCoin                       |
-| 1397       | 0x80000575                    | HYC     | Hycon                             |
-| 1410       | 0x80000582                    | TENTSLP | TENT Simple Ledger Protocol       |
-| 1420       | 0x8000058c                    | DEV     | DogecoinEV                        |
-| 1447       | 0x800005a7                    | DNR     | Dinero                            |
-| 1510       | 0x800005e6                    | XSC     | XT Smart Chain                    |
-| 1512       | 0x800005e8                    | AAC     | Double-A Chain                    |
-| 1524       | 0x800005f4                    |         | Taler                             |
-| 1533       | 0x800005fd                    | BEAM    | Beam                              |
-| 1536       | 0x80000600                    | GAS     | BubiChain                         |
-| 1540       | 0x80000604                    | ATHENA  | Athena                            |
-| 1551       | 0x8000060f                    | SDK     | Sovereign SDK                     |
-| 1555       | 0x80000613                    | APC     | Apc Chain                         |
-| 1616       | 0x80000650                    | ELF     | AELF                              |
-| 1618       | 0x80000652                    | AUDL    | AUDL                              |
-| 1620       | 0x80000654                    | ATH     | Atheios                           |
-| 1627       | 0x8000065b                    | LUME    | Lume Web                          |
-| 1642       | 0x8000066a                    | NEW     | Newton                            |
-| 1657       | 0x80000679                    | BTA     | Btachain                          |
-| 1668       | 0x80000684                    | NEOX    | Neoxa                             |
-| 1669       | 0x80000685                    | MEWC    | Meowcoin                          |
-| 1688       | 0x80000698                    | BCX     | BitcoinX                          |
-| 1707       | 0x800006ab                    | TRMP    | TrumPOW                           |
-| 1729       | 0x800006c1                    | XTZ     | Tezos                             |
-| 1776       | 0x800006f0                    | LBTC    | Liquid BTC                        |
-| 1777       | 0x800006f1                    | BBP     | Biblepay                          |
-| 1784       | 0x800006f8                    | JPYS    | JPY Stablecoin                    |
-| 1788       | 0x800006fc                    | USVAC   | USVACoin                          |
-| 1789       | 0x800006fd                    | VEGA    | Vega Protocol                     |
-| 1815       | 0x80000717                    | ADA     | Cardano                           |
-| 1818       | 0x8000071a                    | CUBE    | Cube Chain Native Token           |
-| 1019       | 0x800003fb                    | ZENO    | Zenotta                           |
-| 1888       | 0x80000760                    | ZTX     | Zetrix                            |
-| 1899       | 0x8000076b                    | XEC     | eCash token                       |
-| 1900       | 0x8000076c                    | XNA     | Neurai                            |
-| 1901       | 0x8000076d                    | CLC     | Classica                          |
-| 1907       | 0x80000773                    | BITCI   | Bitcicoin                         |
-| 1918       | 0x8000077e                    | BKC     | Briskcoin                         |
-| 1919       | 0x8000077f                    | VIPS    | VIPSTARCOIN                       |
-| 1926       | 0x80000786                    | CITY    | City Coin                         |
-| 1935       | 0x8000078f                    | HRC     | Hypercoin                         |
-| 1948       | 0x8000079c                    | DSV     | Doriancoin                        |
-| 1951       | 0x8000079f                    | ESA     | Esa                               |
-| 1952       | 0x800007a0                    | ESC     | EsaCoin                           |
-| 1955       | 0x800007a3                    | XX      | xx coin                           |
-| 1969       | 0x800007b1                    | MVRK    | Mavryk Network                    |
-| 1977       | 0x800007b9                    | XMX     | Xuma                              |
-| 1984       | 0x800007c0                    | TRTL    | TurtleCoin                        |
-| 1985       | 0x800007c1                    | SLRT    | Solarti Chain                     |
-| 1986       | 0x800007c2                    | QTH     | Qing Tong Horizon                 |
-| 1987       | 0x800007c3                    | EGEM    | EtherGem                          |
-| 1988       | 0x800007c4                    | MIRA    | Mira Chain                        |
-| 1989       | 0x800007c5                    | HODL    | HOdlcoin                          |
-| 1990       | 0x800007c6                    | PHL     | Placeholders                      |
-| 1991       | 0x800007c7                    | SC      | Sia                               |
-| 1995       | 0x800007cb                    | MYDOGE  | Mydogecoin                        |
-| 1996       | 0x800007cc                    | MYT     | Mineyourtime                      |
-| 1997       | 0x800007cd                    | POLIS   | Polis                             |
-| 1998       | 0x800007ce                    | XMCC    | Monoeci                           |
-| 1999       | 0x800007cf                    | COLX    | ColossusXT                        |
-| 2000       | 0x800007d0                    | GIN     | GinCoin                           |
-| 2001       | 0x800007d1                    | MNP     | MNPCoin                           |
-| 2002       | 0x800007d2                    | MLN     | Miraland                          |
-| 2003       | 0x800007d3                    | ISNA    | iSarrana                          |
-| 2010       | 0x800007da                    | XBT     | Bitcoin Classic                   |
-| 2013       | 0x800007dd                    | JKC     | Junkcoin                          |
-| 2015       | 0x800007df                    | TEER    | Integritee                        |
-| 2017       | 0x800007e1                    | KIN     | Kin                               |
-| 2018       | 0x800007e2                    | EOSC    | EOSClassic                        |
-| 2019       | 0x800007e3                    | GBT     | GoldBean Token                    |
-| 2020       | 0x800007e4                    | PKC     | PKC                               |
-| 2021       | 0x800007e5                    | SKT     | Sukhavati                         |
-| 2022       | 0x800007e6                    | XHT     | Xinghuo Token                     |
-| 2023       | 0x800007e7                    | COC     | Chat On Chain                     |
-| 2024       | 0x800007e8                    | USBC    | Universal Ledger USBC             |
-| 2025       | 0x800007e9                    | ROCK    | Zenrock Labs                      |
-| 2026       | 0x800007ea                    | ASTRON  | ASTRON Token                      |
-| 2027       | 0x800007eb                    | UNC     | UniCash                           |
-| 2046       | 0x800007fe                    | ANY     | Any                               |
-| 2048       | 0x80000800                    | MCASH   | MCashChain                        |
-| 2049       | 0x80000801                    | TRUE    | TrueChain                         |
-| 2050       | 0x80000802                    | MOVO    | Movo Smart Chain                  |
-| 2086       | 0x80000826                    | KILT    | KILT Spiritnet                    |
-| 2091       | 0x8000082b                    | FRQCY   | Frequency                         |
-| 2102       | 0x80000836                    | LC2     | LitecoinII                        |
-| 2109       | 0x8000083d                    | SAMA    | Exosama Network                   |
-| 2112       | 0x80000840                    | IoTE    | IoTE                              |
-| 2121       | 0x80000849                    | CBTC    | Coordinate BTC (Anduro)           |
-| 2122       | 0x8000084a                    | QBTC    | Quasar BTC (Anduro)               |
-| 2125       | 0x8000084d                    | BAY     | BitBay                            |
-| 2137       | 0x80000859                    | XRG     | Ergon                             |
-| 2199       | 0x80000897                    | SAMA    | Moonsama Network                  |
-| 2221       | 0x800008ad                    | ASK     | ASK                               |
-| 2222       | 0x800008ae                    | CWEB    | Coinweb                           |
-| 2285       | 0x800008ed                    |         | Qiyi Chain                        |
-| 2301       | 0x800008fd                    | QTUM    | QTUM                              |
-| 2302       | 0x800008fe                    | ETP     | Metaverse                         |
-| 2303       | 0x800008ff                    | GXC     | GXChain                           |
-| 2304       | 0x80000900                    | CRP     | CranePay                          |
-| 2305       | 0x80000901                    | ELA     | Elastos                           |
-| 2338       | 0x80000922                    | SNOW    | Snowblossom                       |
-| 2365       | 0x8000093d                    | XIN     | Mixin                             |
-| 2457       | 0x80000999                    | HYPE    | Hyperliquid                       |
-| 2500       | 0x800009c4                    | NEXI    | Nexi                              |
-| 2570       | 0x80000a0a                    | AOA     | Aurora                            |
-| 2626       | 0x80000a42                    | AOXC    | AOXCHAIN                          |
-| 2686       | 0x80000a7e                    | AIPG    | AIPowerGrid                       |
-| 2718       | 0x80000a9e                    | NAS     | Nebulas                           |
-| 2809       | 0x80000af9                    | LAN     | Lanify                            |
-| 2894       | 0x80000b4e                    | REOSC   | REOSC Ecosystem                   |
-| 2941       | 0x80000b7d                    | BND     | Blocknode                         |
-| 3000       | 0x80000bb8                    | SM      | Stealth Message                   |
-| 3003       | 0x80000bbb                    | LUX     | LUX                               |
-| 3030       | 0x80000bd6                    | HBAR    | Hedera HBAR                       |
-| 3054       | 0x80000bee                    | HIVE    | Hive Blockchain                   |
-| 3073       | 0x80000c01                    | MOVE    | Movement                          |
-| 3077       | 0x80000c05                    | COS     | Contentos                         |
-| 3131       | 0x80000c3b                    | DIP     | Dipnet Blockchain                 |
-| 3141       | 0x80000c45                    | B1T     | Bit                               |
-| 3276       | 0x80000ccc                    | CCC     | CodeChain                         |
-| 3344       | 0x80000d10                    | PLMC    | Polimec                           |
-| 3333       | 0x80000d05                    | SXP     | Solar                             |
-| 3338       | 0x80000d0a                    | PEAQ    | peaq                              |
-| 3377       | 0x80000d31                    | ROI     | ROIcoin                           |
-| 3381       | 0x80000d35                    | DYN     | Dynamic                           |
-| 3383       | 0x80000d37                    | SEQ     | Sequence                          |
-| 3434       | 0x80000d6a                    | PEPE    | Pepecoin Core                     |
-| 3499       | 0x80000dab                    | BLAZE   | Blaze                             |
-| 3501       | 0x80000dad                    | JFIN    | JFIN Coin                         |
-| 3552       | 0x80000de0                    | DEO     | Destocoin                         |
-| 3564       | 0x80000dec                    | DST     | DeStream                          |
-| 3601       | 0x80000e11                    | CY      | Cybits                            |
-| 3630       | 0x80000e2e                    | EPPIE   | Eppie                             |
-| 3757       | 0x80000ead                    | MPC     | Partisia Blockchain               |
-| 3840       | 0x80000f00                    | RED     | ReDeFi RED                        |
-| 4040       | 0x80000fc8                    | FC8     | FCH Network                       |
-| 4096       | 0x80001000                    | YEE     | YeeCo                             |
-| 4218       | 0x8000107a                    | IOTA    | IOTA                              |
-| 4219       | 0x8000107b                    | SMR     | Shimmer                           |
-| 4242       | 0x80001092                    | AXE     | Axe                               |
-| 4298       | 0x800010CA                    | LOCA    | Loca                              |
-| 4343       | 0x800010f7                    | XYM     | Symbol                            |
-| 4444       | 0x8000115c                    | C4E     | Chain4Energy                      |
-| 4474       | 0x8000117a                    | SHIC    | ShibaCoin                         |
-| 4646       | 0x80001226                    | MST     | MST                               |
-| 4919       | 0x80001337                    | XVM     | Venidium                          |
-| 4976       | 0x80001370                    | VARA    | Vara                              |
-| 4999       | 0x80001387                    | BXN     | BlackFort Exchange Network        |
-| 5000       | 0x80001388                    | V12     | Vet The Vote                      |
-| 5006       | 0x8000138e                    | SBC     | Senior Blockchain                 |
-| 5248       | 0x80001480                    | FIC     | FIC                               |
-| 5353       | 0x800014e9                    | HNS     | Handshake                         |
-| 5404       | 0x8000151c                    | ISK     | ISKRA                             |
-| 5467       | 0x8000155b                    | ALTME   | ALTME                             |
-| 5555       | 0x800015b3                    | FUND    | Unification                       |
-| 5757       | 0x8000167d                    | STX     | Stacks                            |
-| 5895       | 0x80001707                    | VOW     | VowChain VOW                      |
-| 5920       | 0x80001720                    | SLU     | SILUBIUM                          |
-| 5995       | 0x8000176b                    | DUSK    | Dusk Network                      |
-| 6060       | 0x800017ac                    | GO      | GoChain GO                        |
-| 6144       | 0x80001800                    | DTS     | Datos                             |
-| 6174       | 0x8000181e                    | MOI     | My Own Internet                   |
-| 6278       | 0x80001886                    | STEAMX  | Rails Network Mainnet             |
-| 6310       | 0x800018a6                    | VRL     | Virel Protocol                    |
-| 6383       | 0x800018ef                    | NEUE    | Dap                               |
-| 6532       | 0x80001984                    | UM      | Penumbra                          |
-| 6599       | 0x800019c7                    | RSC     | Royal Sports City                 |
-| 6666       | 0x80001a0a                    | BPA     | Bitcoin Pizza                     |
-| 6688       | 0x80001a20                    | SAFE    | SAFE                              |
-| 6767       | 0x80001a6f                    | CC      | Canton Coin                       |
-| 6779       | 0x80001a7b                    | COTI    | COTI                              |
-| 6969       | 0x80001b39                    | ROGER   | TheHolyrogerCoin                  |
-| 7000       | 0x80001b58                    | ZETA    | ZetaChain                         |
-| 7027       | 0x80001b73                    | ELLA    | Ella the heart                    |
-| 7028       | 0x80001b74                    | AA      | Arthera                           |
-| 7070       | 0x80001b9e                    | DOI     | Doichain                          |
-| 7091       | 0x80001bb3                    | TOPL    | Topl                              |
-| 7272       | 0x80001c68                    | ABTC    | Alys BTC (Anduro)                 |
-| 7331       | 0x80001ca3                    | KLY     | KLYNTAR                           |
-| 7341       | 0x80001cad                    | SHFT    | Shyft                             |
-| 7518       | 0x80001d5e                    | MEV     | MEVerse                           |
-| 7576       | 0x80001d98                    | ADIL    | ADIL Chain                        |
-| 7777       | 0x80001e61                    | BTV     | Bitvote                           |
-| 7779       | 0x80001e63                    | CPV     | Compverse                         |
-| 8000       | 0x80001f40                    | SKY     | Skycoin                           |
-| 8008       | 0x80001f48                    | BERA    | Berachain                         |
-| 8017       | 0x80001f51                    | ISC     | iSunCoin                          |
-| 8080       | 0x80001f90                    |         | DSRV                              |
-| 8181       | 0x80001ff5                    | BOC     | BeOne Chain                       |
-| 8192       | 0x80002000                    | PAC     | pacprotocol                       |
-| 8217       | 0x80002019                    | KAIA    | KAIA                              |
-| 8282       | 0x8000205a                    | HANEUL  | Haneul                            |
-| 8339       | 0x80002093                    | BTQ     | BitcoinQuark                      |
-| 8444       | 0x800020fc                    | XCH     | Chia                              |
-| 8453       | 0x80002105                    |         | Base                              |
-| 8520       | 0x80002148                    | ---     | reserved                          |
-| 8680       | 0x800021e8                    | PLMNT   | Planetmint                        |
-| 8732       | 0x8000221c                    | BLN     | Bullions                          |
-| 8738       | 0x80002222                    | ALPH    | Alph Network                      |
-| 8866       | 0x800022a2                    | GGX     | Golden Gate                       |
-| 8886       | 0x800022b6                    | GGXT    | Golden Gate Sydney                |
-| 8887       | 0x800022b7                    | KTA     | Keeta                             |
-| 8888       | 0x800022b8                    | SBTC    | Super Bitcoin                     |
-| 8964       | 0x80002304                    | NULS    | NULS                              |
-| 8997       | 0x80002325                    | BBC     | Babacoin                          |
-| 8998       | 0x80002326                    | JGC     | JagoanCoin                        |
-| 8999       | 0x80002327                    | BTP     | Bitcoin Pay                       |
-| 9000       | 0x80002328                    | AVAX    | Avalanche                         |
-| 9001       | 0x80002329                    | ARB1    | Arbitrum                          |
-| 9002       | 0x8000232a                    | BOBA    | Boba                              |
-| 9003       | 0x8000232b                    | LOOP    | Loopring                          |
-| 9004       | 0x8000232c                    | STRK    | StarkNet                          |
-| 9005       | 0x8000232d                    | AVAXC   | Avalanche C-Chain                 |
-| 9006       | 0x8000232e                    | BSC     | Binance Smart Chain               |
-| 9007       | 0x8000232f                    | SATOX   | Satoxcoin                         |
-| 9345       | 0x80002481                    | WEIL    | Weilliptic                        |
-| 9555       | 0x80002553                    | RIN     | Rincoin                           |
-| 9797       | 0x80002645                    | NRG     | Energi                            |
-| 9888       | 0x800026a0                    | BTF     | Bitcoin Faith                     |
-| 9969       | 0x800026f1                    | OSMI    | Osmium                            |
-| 9999       | 0x8000270f                    | GOD     | Bitcoin God                       |
-| 10000      | 0x80002710                    | FO      | FIBOS                             |
-| 10001      | 0x80002711                    | SPACE   | Space                             |
-| 10007      | 0x80002717                    | S       | SONIC                             |
-| 10111      | 0x8000277f                    | DHP     | dHealth                           |
-| 10226      | 0x800027f2                    | RTM     | Raptoreum                         |
-| 10242      | 0x80002802                    | AA      | Arthera                           |
-| 10291      | 0x80002833                    | XRC     | XRhodium                          |
-| 10507      | 0x8000290b                    | NUM     | Numbers Protocol                  |
-| 10605      | 0x8000296d                    | XPI     | Lotus                             |
-| 11111      | 0x80002b67                    | ESS     | Essentia One                      |
-| 11742      | 0x80002dde                    | VARCH   | InvArch                           |
-| 11743      | 0x80002ddf                    | TNKR    | Tinkernet                         |
-| 11995      | 0x80002edb                    | AURE    | Aureus                            |
-| 18888      | 0x800049c8                    | BTGS    | BitcoinGold                       |
-| 12345      | 0x80003039                    | IPOS    | IPOS                              |
-| 12586      | 0x8000312a                    | MINA    | Mina                              |
-| 12850      | 0x80003232                    | ANLOG   | Analog Timechain                  |
-| 13107      | 0x80003333                    | BTY     | BitYuan                           |
-| 13108      | 0x80003334                    | YCC     | Yuan Chain Coin                   |
-| 13381      | 0x80003445                    | PHX     | Phoenix                           |
-| 14001      | 0x800036b1                    | WAX     | Worldwide Asset Exchange          |
-| 15845      | 0x80003de5                    | SDGO    | SanDeGo                           |
-| 16181      | 0x80003f35                    | XTX     | Totem Live Network                |
-| 16754      | 0x80004172                    | ARDR    | Ardor                             |
-| 18000      | 0x80004650                    | MTR     | Meter                             |
-| 19165      | 0x80004add                    | SAFE    | Safecoin                          |
-| 19167      | 0x80004adf                    | FLUX    | Flux                              |
-| 19169      | 0x80004ae1                    | RITO    | Ritocoin                          |
-| 19788      | 0x80004d4c                    | ML      | Mintlayer                         |
-| 20036      | 0x80004e44                    | XND     | ndau                              |
-| 20760      | 0x80005118                    | WJK     | WojakCoin                         |
-| 21004      | 0x8000520c                    | C4EI    | c4ei                              |
-| 21337      | 0x80005359                    | XAH     | Xahau                             |
-| 21888      | 0x80005580                    | PAC     | Pactus                            |
-| 22504      | 0x800057e8                    | PWR     | PWRcoin                           |
-| 23000      | 0x800059d8                    | EPIC    | Epic Cash                         |
-| 25252      | 0x800062a4                    | BELL    | Bellcoin                          |
-| 25718      | 0x80006476                    | CHX     | Own                               |
-| 26417      | 0x80006731                    | G1      | Ğ1                                |
-| 29223      | 0x80007227                    | NEXA    | Nexa                              |
-| 30001      | 0x80007531                    | ---     | reserved                          |
-| 31102      | 0x8000797e                    | ESN     | EtherSocial Network               |
-| 31337      | 0x80007a69                    |         | ThePower                          |
-| 33416      | 0x80008288                    | TEO     | Trust Eth reOrigin                |
-| 33878      | 0x80008456                    | BTCS    | Bitcoin Stake                     |
-| 34952      | 0x80008888                    | BTT     | ByteTrade                         |
-| 36969      | 0x80009069                    | AMA     | AMA                               |
-| 37992      | 0x80009468                    | FXTC    | FixedTradeCoin                    |
-| 39321      | 0x80009999                    | AMA     | Amabig                            |
-| 42069      | 0x8000a455                    | FACT    | FACT0RN                           |
-| 43028      | 0x8000a814                    | AXIV    | AXIV                              |
-| 47803      | 0x8000babb                    | BAX     | BAX                               |
-| 49262      | 0x8000c06e                    | EVE     | evan                              |
-| 49344      | 0x8000c0c0                    | STASH   | STASH                             |
-| 52752      | 0x8000ce10                    | CELO    | Celo                              |
-| 54176      | 0x8000d3a0                    | OVER    | OverProtocol                      |
-| 61616      | 0x8000f0b0                    | TH      | TianHe                            |
-| 61888      | 0x8000f200                    | MORM    | Morpheum                          |
-| 65536      | 0x80010000                    | KETH    | Krypton World                     |
-| 69420      | 0x80010f2c                    | GRLC    | Garlicoin                         |
-| 70007      | 0x80011177                    | GWL     | Gewel                             |
-| 83293      | 0x8001455d                    | QUBIC   | Qubic                             |
-| 77777      | 0x80012fd1                    | ZYN     | Wethio                            |
-| 88888      | 0x80015b38                    | RYO     | c0ban                             |
-| 99999      | 0x8001869f                    | WICC    | Waykichain                        |
-| 100500     | 0x80018894                    | HOME    | HomeCoin                          |
-| 101010     | 0x80018a92                    | STC     | Starcoin                          |
-| 104109     | 0x800196ad                    |         | Seed Hypermedia                   |
-| 105105     | 0x80019a91                    | STRAX   | Strax                             |
-| 111111     | 0x8001b207                    | KAS     | Kaspa                             |
-| 121337     | 0x8001d9f9                    | KLS     | Karlsen                           |
-| 123456     | 0x8001e240                    | SPR     | Spectre                           |
-| 130822     | 0x8001ff06                    | WBT     | WhiteBIT Coin                     |
-| 161803     | 0x8002780b                    | APTA    | Bloqs4Good                        |
-| 189189     | 0x8002e305                    | QUAN    | Quantus Network                   |
-| 190301     | 0x8002e75d                    | LOCUS   | Locus Chain                       | 
-| 200625     | 0x80030fb1                    | AKA     | Akroma                            |
-| 200901     | 0x800310c5                    | BTR     | Bitlayer                          |
-| 224433     | 0x80036cb1                    | CONET   | CONET Holesky Network             |
-| 246529     | 0x8003c301                    | ATS     | ARTIS sigma1                      |
-| 251022     | 0x8003d48e                    | AUTOX   | Autox Coin                        |
-| 261131     | 0x8003fc0b                    | ZAMA    | Zama                              |
-| 314159     | 0x8004cb2f                    | PI      | Pi Network                        |
-| 333332     | 0x80051614                    | VALUE   | Value Chain                       |
-| 333333     | 0x80051615                    | 3333    | Pi Value Consensus                |
-| 424242     | 0x80067932                    | X42     | x42                               |
-| 440017     | 0x8006b6d1                    | @G      | Graphite                          |
-| 534352     | 0x80082750                    | SCR     | Scroll                            |
-| 666666     | 0x800a2c2a                    | VITE    | Vite                              |
-| 696365     | 0x800b3206                    | ICE     | Ice Network                       |
-| 696969     | 0x800aa289                    | TXC     | TEXITcoin                         |
-| 827166     | 0x800c9f1e                    |         | RGB on Bitcoin (mainnet)          |
-| 827167     | 0x800c9f1f                    |         | RGB on Bitcoin (testnet)          |
-| 828942     | 0x800ca60e                    |         | RGB on Liquid (mainnet)           |
-| 888888     | 0x800d9038                    | SEA     | Second Exchange Alliance          |
-| 969696     | 0x800ecbe0                    | ISK     | Iskander Coin                     |
-| 1048576    | 0x80100000                    | AMAX    | Armonia Meta Chain                |
-| 1171337    | 0x8011df89                    | ILT     | iOlite                            |
-| 1313114    | 0x8014095a                    | ETHO    | Etho Protocol                     |
-| 1313500    | 0x80140adc                    | XERO    | Xerom                             |
-| 1712144    | 0x801a2010                    | LAX     | LAPO                              |
-| 3924011    | 0x803be02b                    | EPK     | EPIK Protocol                     |
-| 4353123    | 0x80426c63                    | BBLU    | Bitcoin-Blu                       |
-| 4392018    | 0x80430452                    | MCSH    | MetaMask Cash Account             |
-| 4741444    | 0x80485944                    | HYD     | Hydra Token                       |
-| 5063758    | 0x804d444e                    |         | Miden                             |
-| 5249353    | 0x80501949                    | BCO     | BitcoinOre                        |
-| 5249354    | 0x8050194a                    | BHD     | BitcoinHD                         |
-| 5264462    | 0x8050544e                    | PTN     | PalletOne                         |
-| 5655640    | 0x80564c58                    | VLX     | Velas                             |
-| 5718350    | 0x8057414e                    | WAN     | Wanchain                          |
-| 5741564    | 0x80579bfc                    | WAVES   | Waves                             |
-| 5741565    | 0x80579bfd                    | WEST    | Waves Enterprise                  |
-| 6382179    | 0x80616263                    | ABC     | Abcmint                           |
-| 6517357    | 0x8063726d                    | CRM     | Creamcoin                         |
-| 7171666    | 0x806d6e52                    | BROCK   | Bitrock                           |
-| 7562605    | 0x8073656d                    | SEM     | Semux                             |
-| 7567736    | 0x80737978                    | ION     | ION                               |
-| 7777777    | 0x8076adf1                    | FCT     | FirmaChain                        |
-| 7825266    | 0x80776772                    | WGR     | WGR                               |
-| 7825267    | 0x80776773                    | OBSR    | OBServer                          |
-| 8163271    | 0x807c8fc7                    | AFS     | ANFS                              |
-| 8163321    | 0x807c8ff9                    | BTCV    | Bitcoin-Value                     |
-| 10000118   | 0x805d30b6                    | OSMO    | Osmosis                           |
-| 15118976   | 0x80e6b280                    | XDS     | XDS                               |
-| 19000118   | 0x8121eb36                    | SEI     | SEI                               |
-| 22000118   | 0x814fb1f6                    | DYDX    | Dydx                              |
-| 22000119   | 0x814fb1f7                    | INJ     | Injective                         |
-| 61717561   | 0x83adbc39                    | AQUA    | Aquachain                         |
-| 77777777   | 0x84a2cb71                    | AZT     | Aztecoin                          |
-| 88888888   | 0x854c5638                    | HATCH   | Hatch                             |
-| 91927009   | 0x857ab1e1                    | kUSD    | kUSD                              |
-| 99999996   | 0x85f5e0fc                    | GENS    | GENS                              |
-| 99999997   | 0x85f5e0fd                    | EQ      | EQ                                |
-| 99999998   | 0x85f5e0fe                    | FLUID   | Fluid Chains                      |
-| 99999999   | 0x85f5e0ff                    | QKC     | QuarkChain                        |
-| 11259375   | 0x80abcdef                    | LBR     | 0L                                |
-| 20230101   | 0x8134afd5                    | ROH     | Rooch                             |
-| 20240430   | 0x8134d82e                    | NLK     | NuLinkCoin                        |
-| 35600000   | 0x821f3680                    | AXX     | AtlasX Chain                      |
-| 240079435  | 0x8e4f524b                    | ZORK    | Zork Network                      |
-| 268435779  | 0x90000143                    | MON     | Monad                             |
-| 608589380  | 0xa4465644                    | FVDC    | ForumCoin                         |
-| 1010101010 | 0xbc34eb12                    | FAIC    | Free AI Chain                     |
-| 1179993420 | 0xc655454c                    |         | Fuel                              |
-| 1179993421 | 0xc655454d                    | TTNC    | TakeTitan                         |
-| 1179993431 | 0xc6554557                    | MTGBP   | MTGBP                             |
-| 1179993441 | 0xc6554561                    | QFS     | Qfs                               |
-| 1179993451 | 0xc655456b                    | RWA     | Asset Chain                       |
-| 1179993461 | 0xc6554575                    | HXC     | HuaXia Chain                      |
-| 1179993471 | 0xc655457f                    | AME     | AME Chain                         |
-| 1869902945 | 0xef747461                    | ATTO    | Atto                              |
-| 1869902946 | 0xef747462                    | CTA     | Crypterra                         |
+The hardened path component for coin type `n` is computed as `0x80000000 + n`.
+
+| Coin type  | Symbol  | Coin                              |
+| ---------- | ------- | --------------------------------- |
+| 0          | BTC     | Bitcoin                           |
+| 1          |         | Testnet (all coins)               |
+| 2          | LTC     | Litecoin                          |
+| 3          | DOGE    | Dogecoin                          |
+| 4          | RDD     | Reddcoin                          |
+| 5          | DASH    | Dash                              |
+| 6          | PPC     | Peercoin                          |
+| 7          | NMC     | Namecoin                          |
+| 8          | FTC     | Feathercoin                       |
+| 9          | XCP     | Counterparty                      |
+| 10         | BLK     | Blackcoin                         |
+| 11         | NSR     | NuShares                          |
+| 12         | NBT     | NuBits                            |
+| 13         | MZC     | Mazacoin                          |
+| 14         | VIA     | Viacoin                           |
+| 15         | XCH     | ClearingHouse                     |
+| 16         | RBY     | Rubycoin                          |
+| 17         | GRS     | Groestlcoin                       |
+| 18         | DGC     | Digitalcoin                       |
+| 19         | CCN     | Cannacoin                         |
+| 20         | DGB     | DigiByte                          |
+| 21         |         | Open Assets                       |
+| 22         | MONA    | Monacoin                          |
+| 23         | CLAM    | Clams                             |
+| 24         | XPM     | Primecoin                         |
+| 25         | NEOS    | Neoscoin                          |
+| 26         | JBS     | Jumbucks                          |
+| 27         | ZRC     | ziftrCOIN                         |
+| 28         | VTC     | Vertcoin                          |
+| 29         | NXT     | NXT                               |
+| 30         | BURST   | Burst                             |
+| 31         | MUE     | MonetaryUnit                      |
+| 32         | ZOOM    | Zoom                              |
+| 33         | VASH    | Virtual Cash                      |
+| 34         | CDN     | Canada eCoin                      |
+| 35         | SDC     | ShadowCash                        |
+| 36         | PKB     | ParkByte                          |
+| 37         | PND     | Pandacoin                         |
+| 38         | START   | StartCOIN                         |
+| 39         | MOIN    | MOIN                              |
+| 40         | EXP     | Expanse                           |
+| 41         | EMC2    | Einsteinium                       |
+| 42         | DCR     | Decred                            |
+| 43         | XEM     | NEM                               |
+| 44         | PART    | Particl                           |
+| 45         | ARG     | Argentum (dead)                   |
+| 46         |         | Libertas                          |
+| 47         |         | Posw coin                         |
+| 48         | SHR     | Shreeji                           |
+| 49         | GCR     | Global Currency Reserve (GCRcoin) |
+| 50         | NVC     | Novacoin                          |
+| 51         | AC      | Asiacoin                          |
+| 52         | BTCD    | BitcoinDark                       |
+| 53         | DOPE    | Dopecoin                          |
+| 54         | TPC     | Templecoin                        |
+| 55         | AIB     | AIB                               |
+| 56         | EDRC    | EDRCoin                           |
+| 57         | SYS     | Syscoin                           |
+| 58         | SLR     | Solarcoin                         |
+| 59         | SMLY    | Smileycoin                        |
+| 60         | ETH     | Ether                             |
+| 61         | ETC     | Ether Classic                     |
+| 62         | PSB     | Pesobit                           |
+| 63         | LDCN    | Landcoin (dead)                   |
+| 64         |         | Open Chain                        |
+| 65         | XBC     | Bitcoinplus                       |
+| 66         | IOP     | Internet of People                |
+| 67         | NXS     | Nexus                             |
+| 68         | INSN    | InsaneCoin                        |
+| 69         | OK      | OKCash                            |
+| 70         | BRIT    | BritCoin                          |
+| 71         | CMP     | Compcoin                          |
+| 72         | CRW     | Crown                             |
+| 73         | BELA    | BelaCoin                          |
+| 74         | ICX     | ICON                              |
+| 75         | FJC     | FujiCoin                          |
+| 76         | MIX     | MIX                               |
+| 77         | XVG     | Verge Currency                    |
+| 78         | EFL     | Electronic Gulden                 |
+| 79         | CLUB    | ClubCoin                          |
+| 80         | RICHX   | RichCoin                          |
+| 81         | POT     | Potcoin                           |
+| 82         | QRK     | Quarkcoin                         |
+| 83         | TRC     | Terracoin                         |
+| 84         | GRC     | Gridcoin                          |
+| 85         | AUR     | Auroracoin                        |
+| 86         | IXC     | IXCoin                            |
+| 87         | NLG     | Gulden                            |
+| 88         | BITB    | BitBean                           |
+| 89         | BTA     | Bata                              |
+| 90         | XMY     | Myriadcoin                        |
+| 91         | BSD     | BitSend                           |
+| 92         | UNO     | Unobtanium                        |
+| 93         | MTR     | MasterTrader                      |
+| 94         | GB      | GoldBlocks                        |
+| 95         | SHM     | Saham                             |
+| 96         | CRX     | Chronos                           |
+| 97         | BIQ     | Ubiquoin                          |
+| 98         | EVO     | Evotion                           |
+| 99         | STO     | SaveTheOcean                      |
+| 100        | BIGUP   | BigUp                             |
+| 101        | GAME    | GameCredits                       |
+| 102        | DLC     | Dollarcoins                       |
+| 103        | ZYD     | Zayedcoin                         |
+| 104        | DBIC    | Dubaicoin                         |
+| 105        | STRAT   | Stratis                           |
+| 106        | SH      | Shilling                          |
+| 107        | MARS    | MarsCoin                          |
+| 108        | UBQ     | Ubiq                              |
+| 109        | PTC     | Pesetacoin                        |
+| 110        | NRO     | Neurocoin                         |
+| 111        | ARK     | ARK                               |
+| 112        | USC     | UltimateSecureCashMain            |
+| 113        | THC     | Hempcoin                          |
+| 114        | LINX    | Linx                              |
+| 115        | ECN     | Ecoin                             |
+| 116        | DNR     | Denarius                          |
+| 117        | PINK    | Pinkcoin                          |
+| 118        | ATOM    | Atom                              |
+| 119        | PIVX    | Pivx                              |
+| 120        | FLASH   | Flashcoin                         |
+| 121        | ZEN     | Zencash                           |
+| 122        | PUT     | Putincoin                         |
+| 123        | ZNY     | BitZeny                           |
+| 124        | UNIFY   | Unify                             |
+| 125        | XST     | StealthCoin                       |
+| 126        | BRK     | Breakout Coin                     |
+| 127        | VC      | Vcash                             |
+| 128        | XMR     | Monero                            |
+| 129        | VOX     | Voxels                            |
+| 130        | NAV     | NavCoin                           |
+| 131        | FCT     | Factom Factoids                   |
+| 132        | EC      | Factom Entry Credits              |
+| 133        | ZEC     | Zcash                             |
+| 134        | LSK     | Lisk                              |
+| 135        | STEEM   | Steem                             |
+| 136        | XZC     | ZCoin                             |
+| 137        | RBTC    | Rootstock                         |
+| 138        |         | Giftblock                         |
+| 139        | RPT     | RealPointCoin                     |
+| 140        | LBC     | LBRY Credits                      |
+| 141        | KMD     | Komodo                            |
+| 142        | BSQ     | bisq Token                        |
+| 143        | RIC     | Riecoin                           |
+| 144        | XRP     | XRP                               |
+| 145        | BCH     | Bitcoin Cash                      |
+| 146        | NEBL    | Neblio                            |
+| 147        | ZCL     | ZClassic                          |
+| 148        | XLM     | Stellar Lumens                    |
+| 149        | NLC2    | NoLimitCoin2                      |
+| 150        | WHL     | WhaleCoin                         |
+| 151        | ERC     | EuropeCoin                        |
+| 152        | DMD     | Diamond                           |
+| 153        | BTM     | Bytom                             |
+| 154        | BIO     | Biocoin                           |
+| 155        | XWCC    | Whitecoin Classic                 |
+| 156        | BTG     | Bitcoin Gold                      |
+| 157        | BTC2X   | Bitcoin 2x                        |
+| 158        | SSN     | SuperSkynet                       |
+| 159        | TOA     | TOACoin                           |
+| 160        | BTX     | Bitcore                           |
+| 161        | ACC     | Adcoin                            |
+| 162        | BCO     | Bridgecoin                        |
+| 163        | ELLA    | Ellaism                           |
+| 164        | PIRL    | Pirl                              |
+| 165        | XNO     | Nano                              |
+| 166        | VIVO    | Vivo                              |
+| 167        | FRST    | Firstcoin                         |
+| 168        | HNC     | Helleniccoin                      |
+| 169        | BUZZ    | BUZZ                              |
+| 170        | MBRS    | Ember                             |
+| 171        | HC      | Hcash                             |
+| 172        | HTML    | HTMLCOIN                          |
+| 173        | ODN     | Obsidian                          |
+| 174        | ONX     | OnixCoin                          |
+| 175        | RVN     | Ravencoin                         |
+| 176        | GBX     | GoByte                            |
+| 177        | BTCZ    | BitcoinZ                          |
+| 178        | POA     | Poa                               |
+| 179        | NYC     | NewYorkCoin                       |
+| 180        | MXT     | MarteXcoin                        |
+| 181        | WC      | Wincoin                           |
+| 182        | MNX     | Minexcoin                         |
+| 183        | BTCP    | Bitcoin Private                   |
+| 184        | MUSIC   | Musicoin                          |
+| 185        | BCA     | Bitcoin Atom                      |
+| 186        | CRAVE   | Crave                             |
+| 187        | STAK    | STRAKS                            |
+| 188        | WBTC    | World Bitcoin                     |
+| 189        | LCH     | LiteCash                          |
+| 190        | EXCL    | ExclusiveCoin                     |
+| 191        | LYNX    | Lynx                              |
+| 192        | LCC     | LitecoinCash                      |
+| 193        | XFE     | Feirm                             |
+| 194        | EOS     | EOS                               |
+| 195        | TRX     | Tron                              |
+| 196        | KOBO    | Kobocoin                          |
+| 197        | HUSH    | HUSH                              |
+| 198        | BAN     | Banano                            |
+| 199        | ETF     | ETF                               |
+| 200        | OMNI    | Omni                              |
+| 201        | BIFI    | BitcoinFile                       |
+| 202        | UFO     | Uniform Fiscal Object             |
+| 203        | CNMC    | Cryptonodes                       |
+| 204        | BCN     | Bytecoin                          |
+| 205        | RIN     | Ringo                             |
+| 206        | ATP     | Alaya                             |
+| 207        | EVT     | everiToken                        |
+| 208        | ATN     | ATN                               |
+| 209        | BIS     | Bismuth                           |
+| 210        | NEET    | NEETCOIN                          |
+| 211        | BOPO    | BopoChain                         |
+| 212        | OOT     | Utrum                             |
+| 213        | ALIAS   | Alias                             |
+| 214        | MONK    | Monkey Project                    |
+| 215        | BOXY    | BoxyCoin                          |
+| 216        | FLO     | Flo                               |
+| 217        | MEC     | Megacoin                          |
+| 218        | BTDX    | BitCloud                          |
+| 219        | XAX     | Artax                             |
+| 220        | ANON    | ANON                              |
+| 221        | LTZ     | LitecoinZ                         |
+| 222        | BITG    | Bitcoin Green                     |
+| 223        | ICP     | Internet Computer (DFINITY)       |
+| 224        | SMART   | Smartcash                         |
+| 225        | XUEZ    | XUEZ                              |
+| 226        | HLM     | Helium                            |
+| 227        | WEB     | Webchain                          |
+| 228        | ACM     | Actinium                          |
+| 229        | NOS     | NOS Stable Coins                  |
+| 230        | BITC    | BitCash                           |
+| 231        | HTH     | Help The Homeless Coin            |
+| 232        | TZC     | Trezarcoin                        |
+| 233        | VAR     | Varda                             |
+| 234        | IOV     | IOV                               |
+| 235        | FIO     | FIO                               |
+| 236        | BSV     | BitcoinSV                         |
+| 237        | DXN     | DEXON                             |
+| 238        | QRL     | Quantum Resistant Ledger          |
+| 239        | PCX     | ChainX                            |
+| 240        | LOKI    | Loki                              |
+| 241        |         | Imagewallet                       |
+| 242        | NIM     | Nimiq                             |
+| 243        | SOV     | Sovereign Coin                    |
+| 244        | JCT     | Jibital Coin                      |
+| 245        | SLP     | Simple Ledger Protocol            |
+| 246        | EWT     | Energy Web                        |
+| 247        | UC      | Ulord                             |
+| 248        | EXOS    | EXOS                              |
+| 249        | ECA     | Electra                           |
+| 250        | SOOM    | Soom                              |
+| 251        | XRD     | Redstone                          |
+| 252        | FREE    | FreeCoin                          |
+| 253        | NPW     | NewPowerCoin                      |
+| 254        | BST     | BlockStamp                        |
+| 255        |         | SmartHoldem                       |
+| 256        | NANO    | Bitcoin Nano                      |
+| 257        | BTCC    | Bitcoin Core                      |
+| 258        |         | Zen Protocol                      |
+| 259        | ZEST    | Zest                              |
+| 260        | ABT     | ArcBlock                          |
+| 261        | PION    | Pion                              |
+| 262        | DT3     | DreamTeam3                        |
+| 263        | ZBUX    | Zbux                              |
+| 264        | KPL     | Kepler                            |
+| 265        | TPAY    | TokenPay                          |
+| 266        | ZILLA   | ChainZilla                        |
+| 267        | ANK     | Anker                             |
+| 268        | BCC     | BCChain                           |
+| 269        | HPB     | HPB                               |
+| 270        | ONE     | ONE                               |
+| 271        | SBC     | SBC                               |
+| 272        | IPC     | IPChain                           |
+| 273        | DMTC    | Dominantchain                     |
+| 274        | OGC     | Onegram                           |
+| 275        | SHIT    | Shitcoin                          |
+| 276        | ANDES   | Andescoin                         |
+| 277        | AREPA   | Arepacoin                         |
+| 278        | BOLI    | Bolivarcoin                       |
+| 279        | RIL     | Rilcoin                           |
+| 280        | HTR     | Hathor Network                    |
+| 281        | ACME    | Accumulate                        |
+| 282        | BRAVO   | BRAVO                             |
+| 283        | ALGO    | Algorand                          |
+| 284        | BZX     | Bitcoinzero                       |
+| 285        | GXX     | GravityCoin                       |
+| 286        | HEAT    | HEAT                              |
+| 287        | XDN     | DigitalNote                       |
+| 288        | FSN     | FUSION                            |
+| 289        | CPC     | Capricoin                         |
+| 290        | BOLD    | Bold                              |
+| 291        | IOST    | IOST                              |
+| 292        | TKEY    | Tkeycoin                          |
+| 293        | USE     | Usechain                          |
+| 294        | BCZ     | BitcoinCZ                         |
+| 295        | IOC     | Iocoin                            |
+| 296        | ASF     | Asofe                             |
+| 297        | MASS    | MASS                              |
+| 298        | FAIR    | FairCoin                          |
+| 299        | NUKO    | Nekonium                          |
+| 300        | GNX     | Genaro Network                    |
+| 301        | DIVI    | Divi Project                      |
+| 302        | CMT     | Community                         |
+| 303        | EUNO    | EUNO                              |
+| 304        | IOTX    | IoTeX                             |
+| 305        | ONION   | DeepOnion                         |
+| 306        | 8BIT    | 8Bit                              |
+| 307        | ATC     | AToken Coin                       |
+| 308        | BTS     | Bitshares                         |
+| 309        | CKB     | Nervos CKB                        |
+| 310        | UGAS    | Ultrain                           |
+| 311        | ADS     | Adshares                          |
+| 312        | ARA     | Aura                              |
+| 313        | ZIL     | Zilliqa                           |
+| 314        | MOAC    | MOAC                              |
+| 315        | SWTC    | SWTC                              |
+| 316        | VNSC    | vnscoin                           |
+| 317        | PLUG    | Pl^g                              |
+| 318        | MAN     | Matrix AI Network                 |
+| 319        | ECC     | ECCoin                            |
+| 320        | RPD     | Rapids                            |
+| 321        | RAP     | Rapture                           |
+| 322        | GARD    | Hashgard                          |
+| 323        | ZER     | Zero                              |
+| 324        | EBST    | eBoost                            |
+| 325        | SHARD   | Shard                             |
+| 326        | MRX     | Metrix Coin                       |
+| 327        | CMM     | Commercium                        |
+| 328        | BLOCK   | Blocknet                          |
+| 329        | AUDAX   | AUDAX                             |
+| 330        | LUNA    | Terra                             |
+| 331        | ZPM     | zPrime                            |
+| 332        | KUVA    | Kuva Utility Note                 |
+| 333        | MEM     | MemCoin                           |
+| 334        | CS      | Credits                           |
+| 335        | SWIFT   | SwiftCash                         |
+| 336        | FIX     | FIX                               |
+| 337        | CPC     | CPChain                           |
+| 338        | VGO     | VirtualGoodsToken                 |
+| 339        | DVT     | DeVault                           |
+| 340        | N8V     | N8VCoin                           |
+| 341        | MTNS    | OmotenashiCoin                    |
+| 342        | BLAST   | BLAST                             |
+| 343        | DCT     | DECENT                            |
+| 344        | AUX     | Auxilium                          |
+| 345        | USDP    | USDP                              |
+| 346        | HTDF    | HTDF                              |
+| 347        | YEC     | Ycash                             |
+| 348        | QLC     | QLC Chain                         |
+| 349        | TEA     | Icetea Blockchain                 |
+| 350        | ARW     | ArrowChain                        |
+| 351        | MDM     | Medium                            |
+| 352        | CYB     | Cybex                             |
+| 353        | LTO     | LTO Network                       |
+| 354        | DOT     | Polkadot                          |
+| 355        | AEON    | Aeon                              |
+| 356        | RES     | Resistance                        |
+| 357        | AYA     | Aryacoin                          |
+| 358        | DAPS    | Dapscoin                          |
+| 359        | CSC     | CasinoCoin                        |
+| 360        | VSYS    | V Systems                         |
+| 361        | NOLLAR  | Nollar                            |
+| 362        | XNOS    | NOS                               |
+| 363        | CPU     | CPUchain                          |
+| 364        | LAMB    | Lambda Storage Chain              |
+| 365        | VCT     | ValueCyber                        |
+| 366        | CZR     | Canonchain                        |
+| 367        | ABBC    | ABBC                              |
+| 368        | HET     | HET                               |
+| 369        | XAS     | Asch                              |
+| 370        | VDL     | Vidulum                           |
+| 371        | MED     | MediBloc                          |
+| 372        | ZVC     | ZVChain                           |
+| 373        | VESTX   | Vestx                             |
+| 374        | DBT     | DarkBit                           |
+| 375        | SEOS    | SuperEOS                          |
+| 376        | MXW     | Maxonrow                          |
+| 377        | ZNZ     | ZENZO                             |
+| 378        | XCX     | XChain                            |
+| 379        | SOX     | SonicX                            |
+| 380        | NYZO    | Nyzo                              |
+| 381        | ULC     | ULCoin                            |
+| 382        | RYO     | Ryo Currency                      |
+| 383        | KAL     | Kaleidochain                      |
+| 384        | XSN     | Stakenet                          |
+| 385        | DOGEC   | DogeCash                          |
+| 386        | BMV     | Bitcoin Matteo's Vision           |
+| 387        | QBC     | Quebecoin                         |
+| 388        | IMG     | ImageCoin                         |
+| 389        | QOS     | QOS                               |
+| 390        | PKT     | PKT                               |
+| 391        | LHD     | LitecoinHD                        |
+| 392        | CENNZ   | CENNZnet                          |
+| 393        | HSN     | Hyper Speed Network               |
+| 394        | CRO     | Crypto Chain                      |
+| 395        | UMBRU   | Umbru                             |
+| 396        | EVER    | Everscale                         |
+| 397        | NEAR    | NEAR Protocol                     |
+| 398        | XPC     | XPChain                           |
+| 399        | ZOC     | 01coin                            |
+| 400        | NIX     | NIX                               |
+| 401        | UC      | Utopiacoin                        |
+| 402        | GALI    | Galilel                           |
+| 403        | OLT     | Oneledger                         |
+| 404        | XBI     | XBI                               |
+| 405        | DONU    | DONU                              |
+| 406        | EARTHS  | Earths                            |
+| 407        | HDD     | HDDCash                           |
+| 408        | SUGAR   | Sugarchain                        |
+| 409        | AILE    | AileCoin                          |
+| 410        | TENT    | TENT                              |
+| 411        | TAN     | Tangerine Network                 |
+| 412        | AIN     | AIN                               |
+| 413        | MSR     | Masari                            |
+| 414        | SUMO    | Sumokoin                          |
+| 415        | ETN     | Electroneum                       |
+| 416        | BYTZ    | BYTZ                              |
+| 417        | WOW     | Wownero                           |
+| 418        | XTNC    | XtendCash                         |
+| 419        | LTHN    | Lethean                           |
+| 420        | NODE    | NodeHost                          |
+| 421        | AGM     | Argoneum                          |
+| 422        | CCX     | Conceal Network                   |
+| 423        | TNET    | Title Network                     |
+| 424        | TELOS   | TelosCoin                         |
+| 425        | AION    | Aion                              |
+| 426        | BC      | Bitcoin Confidential              |
+| 427        | KTV     | KmushiCoin                        |
+| 428        | ZCR     | ZCore                             |
+| 429        | ERG     | Ergo                              |
+| 430        | PESO    | Criptopeso                        |
+| 431        | BTC2    | Bitcoin 2                         |
+| 432        | XRPHD   | XRPHD                             |
+| 433        | WE      | WE Coin                           |
+| 434        | KSM     | Kusama                            |
+| 435        | PCN     | Peepcoin                          |
+| 436        | NCH     | NetCloth                          |
+| 437        | ICU     | CHIPO                             |
+| 438        | FNSA    | FINSCHIA                          |
+| 439        | DTP     | DeVault Token Protocol            |
+| 440        | BTCR    | Bitcoin Royale                    |
+| 441        | AERGO   | AERGO                             |
+| 442        | XTH     | Dothereum                         |
+| 443        | LV      | Lava                              |
+| 444        | PHR     | Phore                             |
+| 445        | VITAE   | Vitae                             |
+| 446        | COCOS   | Cocos-BCX                         |
+| 447        | DIN     | Dinero                            |
+| 448        | SPL     | Simplicity                        |
+| 449        | YCE     | MYCE                              |
+| 450        | XLR     | Solaris                           |
+| 451        | KTS     | Klimatas                          |
+| 452        | DGLD    | DGLD                              |
+| 453        | XNS     | Insolar                           |
+| 454        | EM      | EMPOW                             |
+| 455        | SHN     | ShineBlocks                       |
+| 456        | SEELE   | Seele                             |
+| 457        | AE      | æternity                          |
+| 458        | ODX     | ObsidianX                         |
+| 459        | KAVA    | Kava                              |
+| 460        | GLEEC   | GLEEC                             |
+| 461        | FIL     | Filecoin                          |
+| 462        | RUTA    | Rutanio                           |
+| 463        | CSDT    | CSDT                              |
+| 464        | ETI     | EtherInc                          |
+| 465        | ZSLP    | Zclassic Simple Ledger Protocol   |
+| 466        | ERE     | EtherCore                         |
+| 467        | DX      | DxChain Token                     |
+| 468        | CPS     | Capricoin+                        |
+| 469        | BTH     | Bithereum                         |
+| 470        | MESG    | MESG                              |
+| 471        | FIMK    | FIMK                              |
+| 472        | AR      | Arweave                           |
+| 473        | OGO     | Origo                             |
+| 474        | ROSE    | Oasis Network                     |
+| 475        | BARE    | BARE Network                      |
+| 476        | GLEEC   | GleecBTC                          |
+| 477        | CLR     | Color Coin                        |
+| 478        | RNG     | Ring                              |
+| 479        | OLO     | Tool Global                       |
+| 480        | PEXA    | Pexa                              |
+| 481        | MOON    | Mooncoin                          |
+| 482        | OCEAN   | Ocean Protocol                    |
+| 483        | BNT     | Bluzelle Native                   |
+| 484        | AMO     | AMO Blockchain                    |
+| 485        | FCH     | FreeCash                          |
+| 486        | LAT     | PlatON                            |
+| 487        | COIN    | Bitcoin Bank                      |
+| 488        | VEO     | Amoveo                            |
+| 489        | CCA     | Counos Coin                       |
+| 490        | GFN     | Graphene                          |
+| 491        | BIP     | Minter Network                    |
+| 492        | KPG     | Kunpeng Network                   |
+| 493        | FIN     | FINL Chain                        |
+| 494        | BAND    | Band                              |
+| 495        | DROP    | Dropil                            |
+| 496        | BHT     | Bluehelix Chain                   |
+| 497        | LYRA    | Scrypta                           |
+| 498        | CS      | Credits                           |
+| 499        | RUPX    | Rupaya                            |
+| 500        | THETA   | Theta                             |
+| 501        | SOL     | Solana                            |
+| 502        | THT     | ThoughtAI                         |
+| 503        | CFX     | Conflux                           |
+| 504        | KUMA    | Kumacoin                          |
+| 505        | HASH    | Provenance                        |
+| 506        | CSPR    | Casper                            |
+| 507        | EARTH   | EARTH                             |
+| 508        | EGLD    | MultiversX                        |
+| 509        | CHI     | Xaya                              |
+| 510        | KOTO    | Koto                              |
+| 511        | OTC     | θ                                 |
+| 512        | RXD     | Radiant                           |
+| 513        | SEELEN  | Seele-N                           |
+| 514        | AETH    | AETH                              |
+| 515        | DNA     | Idena                             |
+| 516        | VEE     | Virtual Economy Era               |
+| 517        | SIERRA  | SierraCoin                        |
+| 518        | LET     | Linkeye                           |
+| 519        | BSC     | Bitcoin Smart Contract            |
+| 520        | BTCV    | BitcoinVIP                        |
+| 521        | ABA     | Dabacus                           |
+| 522        | SCC     | StakeCubeCoin                     |
+| 523        | EDG     | Edgeware                          |
+| 524        | AMS     | AmsterdamCoin                     |
+| 525        | GOSS    | GOSSIP Coin                       |
+| 526        | BU      | BUMO                              |
+| 527        | GRAM    | GRAM                              |
+| 528        | YAP     | Yapstone                          |
+| 529        | SCRT    | Secret Network                    |
+| 530        | NOVO    | Novo                              |
+| 531        | GHOST   | Ghost                             |
+| 532        | HST     | HST                               |
+| 533        | PRJ     | ProjectCoin                       |
+| 534        | YOU     | YOUChain                          |
+| 535        | XHV     | Haven Protocol                    |
+| 536        | BYND    | Beyondcoin                        |
+| 537        | JOYS    | Joys Digital                      |
+| 538        | VAL     | Valorbit                          |
+| 539        | FLOW    | Flow                              |
+| 540        | SMESH   | Spacemesh Coin                    |
+| 541        | SCDO    | SCDO                              |
+| 542        | IQS     | IQ-Cash                           |
+| 543        | BIND    | Compendia                         |
+| 544        | COINEVO | Coinevo                           |
+| 545        | SCRIBE  | Scribe                            |
+| 546        | HYN     | Hyperion                          |
+| 547        | BHP     | BHP                               |
+| 548        | BBC     | BigBang Core                      |
+| 549        | MKF     | MarketFinance                     |
+| 550        | XDC     | XinFin                            |
+| 551        | STR     | Straightedge                      |
+| 552        | SUM     | Sumcoin                           |
+| 553        | HBC     | HuobiChain                        |
+| 554        | ---     | reserved                          |
+| 555        | BCS     | Bitcoin Smart                     |
+| 556        | KTS     | Kratos                            |
+| 557        | LKR     | Lkrcoin                           |
+| 558        | TAO     | Tao                               |
+| 559        | XWC     | Whitecoin                         |
+| 560        | DEAL    | DEAL                              |
+| 561        | NTY     | Nexty                             |
+| 562        | TOP     | TOP NetWork                       |
+| 563        | ---     | reserved                          |
+| 564        | AG      | Agoric                            |
+| 565        | CICO    | Coinicles                         |
+| 566        | IRIS    | Irisnet                           |
+| 567        | NCG     | Nine Chronicles                   |
+| 568        | LRG     | Large Coin                        |
+| 569        | SERO    | Super Zero Protocol               |
+| 570        | BDX     | Beldex                            |
+| 571        | CCXX    | Counos X                          |
+| 572        | SLS     | Saluscoin                         |
+| 573        | SRM     | Serum                             |
+| 574        | ---     | reserved                          |
+| 575        | VIVT    | VIDT Datalink                     |
+| 576        | BPS     | BitcoinPoS                        |
+| 577        | NKN     | NKN                               |
+| 578        | ICL     | ILCOIN                            |
+| 579        | BONO    | Bonorum                           |
+| 580        | PLC     | PLATINCOIN                        |
+| 581        | DUN     | Dune                              |
+| 582        | DMCH    | Darmacash                         |
+| 583        | CTC     | Creditcoin                        |
+| 584        | KELP    | Haidai Network                    |
+| 585        | GBCR    | GoldBCR                           |
+| 586        | XDAG    | XDAG                              |
+| 587        | PRV     | Incognito Privacy                 |
+| 588        | SCAP    | SafeCapital                       |
+| 589        | TFUEL   | Theta Fuel                        |
+| 590        | GTM     | Gentarium                         |
+| 591        | RNL     | RentalChain                       |
+| 592        | GRIN    | Grin                              |
+| 593        | MWC     | MimbleWimbleCoin                  |
+| 594        | DOCK    | Dock                              |
+| 595        | POLYX   | Polymesh                          |
+| 596        | DIVER   | Divergenti                        |
+| 597        | XEP     | Electra Protocol                  |
+| 598        | APN     | Apron                             |
+| 599        | TFC     | Turbo File Coin                   |
+| 600        | UTE     | Unit-e                            |
+| 601        | MTC     | Metacoin                          |
+| 602        | NC      | NobodyCash                        |
+| 603        | XINY    | Xinyuehu                          |
+| 604        | DYN     | Dynamo                            |
+| 605        | BUFS    | Buffer                            |
+| 606        | STOS    | Stratos                           |
+| 607        | TON     | TON                               |
+| 608        | TAFT    | TAFT                              |
+| 609        | HYDRA   | HYDRA                             |
+| 610        | NOR     | Noir                              |
+| 611        |         | Manta Network Private Asset       |
+| 612        |         | Calamari Network Private Asset    |
+| 613        | WCN     | Widecoin                          |
+| 614        | OPT     | Optimistic Ethereum               |
+| 615        | PSWAP   | PolkaSwap                         |
+| 616        | VAL     | Validator                         |
+| 617        | XOR     | Sora                              |
+| 618        | SSP     | SmartShare                        |
+| 619        | DEI     | DeimosX                           |
+| 620        | ---     | reserved                          |
+| 621        | ZERO    | Singularity                       |
+| 622        | ALPHA   | AlphaDAO                          |
+| 623        | BDECO   | BDCashProtocol Ecosystem          |
+| 624        | NOBL    | Nobility                          |
+| 625        | EAST    | Eastcoin                          |
+| 626        | KDA     | Kadena                            |
+| 627        | SOUL    | Phantasma                         |
+| 628        | LORE    | Gitopia                           |
+| 629        | FNR     | Fincor                            |
+| 630        | NEXUS   | Nexus                             |
+| 631        | QTZ     | Quartz                            |
+| 632        | MAS     | Massa                             |
+| 633        | CALL    | Callchain                         |
+| 634        | VAL     | Validity                          |
+| 635        | POKT    | Pocket Network                    |
+| 636        | EMIT    | EMIT                              |
+| 637        | APTOS   | Aptos                             |
+| 638        | ADON    | ADON                              |
+| 639        | BTSG    | BitSong                           |
+| 640        | LFC     | Leofcoin                          |
+| 641        | KCS     | KuCoin Shares                     |
+| 642        | KCC     | KuCoin Community Chain            |
+| 643        | AZERO   | Aleph Zero                        |
+| 644        | TREE    | Tree                              |
+| 645        | LX      | Lynx                              |
+| 646        | XLN     | Lunarium                          |
+| 647        | CIC     | CIC Chain                         |
+| 648        | ZRB     | Zarb                              |
+| 649        | ---     | reserved                          |
+| 650        | UCO     | Archethic                         |
+| 651        | SFX     | Safex Cash                        |
+| 652        | SFT     | Safex Token                       |
+| 653        | WSFX    | Wrapped Safex Cash                |
+| 654        | USDG    | US Digital Gold                   |
+| 655        | WMP     | WAMP                              |
+| 656        | EKTA    | Ekta                              |
+| 657        | YDA     | YadaCoin                          |
+| 658        | WHIVE   | Whive                             |
+| 659        | KOIN    | Koinos                            |
+| 660        | PIRATE  | PirateCash                        |
+| 661        | UNQ     | Unique                            |
+| 662        | ULM     | UltonSmartchain                   |
+| 663        | SFRX    | EtherGem Sapphire                 |
+| 664        | BSTY    | GlobalBoost-Y                     |
+| 665        | IMP     | Impact Protocol                   |
+| 666        | ACT     | Achain                            |
+| 667        | PRKL    | Perkle                            |
+| 668        | SSC     | SelfSell                          |
+| 669        | GC      | GateChain                         |
+| 670        | PLGR    | Pledger                           |
+| 671        | MPLGR   | Pledger                           |
+| 672        | KNOX    | Knox                              |
+| 673        | ZED     | ZED                               |
+| 674        | CNDL    | Candle                            |
+| 675        | WLKR    | Walker Crypto Innovation Index    |
+| 676        | WLKRR   | Walker                            |
+| 677        | YUNGE   | Yunge                             |
+| 678        | Voken   | Voken                             |
+| 679        | APL     | Apollo                            |
+| 680        | Evrynet | Evrynet                           |
+| 681        | NENG    | Nengcoin                          |
+| 682        | CHTA    | Cheetahcoin                       |
+| 683        | ALEO    | Aleo Network                      |
+| 684        | HMS     | Hemis                             |
+| 685        | OAS     | Oasys                             |
+| 686        | KAR     | Karura Network                    |
+| 687        | FLON    | FullOn Network                    |
+| 688        | CET     | CoinEx Chain                      |
+| 689        | XLINK   | XLink Chain                       |
+| 690        | KLV     | KleverChain                       |
+| 691        | TNT     | Tangle                            |
+| 692        | GTG     | Gotigin                           |
+| 693        | NET     | RealityNet                        |
+| 694        | VTBC    | VTB Community                     |
+| 695        | DIONE   | Odyssey Chain                     |
+| 696        | LUM     | Lumos                             |
+| 697        | AVA     | Avalon                            |
+| 698        | VEIL    | Veil                              |
+| 699        | GTB     | GotaBit                           |
+| 700        | XDAI    | xDai                              |
+| 701        | COM     | Commercio                         |
+| 702        | CCC     | Commercio Cash Credit             |
+| 703        | SNR     | Sonr                              |
+| 704        | RAQ     | Ra Quantum                        |
+| 705        | PEG     | Pegasus Token                     |
+| 706        | LKG     | Lionking                          |
+| 707        | MCOIN   | Moneta Coin                       |
+| 708        | ---     | reserved                          |
+| 709        | AVAIL   | Avail                             |
+| 710        | FURY    | Highbury                          |
+| 711        | CHC     | Chaincoin                         |
+| 712        | SERF    | Serfnet                           |
+| 713        | XTL     | Katal Chain                       |
+| 714        | BNB     | Binance                           |
+| 715        | SIN     | Sinovate                          |
+| 716        | DLN     | Delion                            |
+| 717        | BONTE   | Bontecoin                         |
+| 718        | PEER    | Peer                              |
+| 719        | ZET     | Zetacoin                          |
+| 720        | ABY     | Artbyte                           |
+| 721        | PGX     | Mirai Chain                       |
+| 722        | IL8P    | InfiniLooP                        |
+| 723        | VOI     | Voi                               |
+| 724        | XVC     | Vanillacash                       |
+| 725        | MCX     | MultiCash                         |
+| 726        | TARA    | Taraxa                            |
+| 727        | BLU     | BluCrates                         |
+| 728        | BFC     | BFC                               |
+| 729        | DCC     | DecentraCast                      |
+| 730        | HEALIOS | Tenacity                          |
+| 731        | BMK     | Bitmark                           |
+| 732        | FUGA    | Fuga token                        |
+| 733        | TBC     | TBChat                            |
+| 734        | DENTX   | DENTNet                           |
+| 735        | NBY     | Neobytes                          |
+| 736        | BABY    | BABY                              |
+| 737        | ATOP    | Financial Blockchain              |
+| 738        | BTE     | Bitweb                            |
+| 739        | DPC     | Dpowcoin (DualPowCoin)            |
+| 740        | MDC     | MyDataCoin                        |
+| 741        | RIV     | Rigvid                            |
+| 742        | LTO     | LTO Network                       |
+| 743        | LKY     | LuckyCoin                         |
+| 744        | DUSK    | Dusk                              |
+| 745        | DIMI    | DiminutiveCoin                    |
+| 746        | PLM     | Palladium                         |
+| 747        | CFG     | Centrifuge                        |
+| 748        |         |                                   |
+| 749        |         |                                   |
+| 750        | XPRT    | Persistence                       |
+| 751        |         |                                   |
+| 752        |         |                                   |
+| 753        |         | Age X25519 Encryption             |
+| 754        |         | Age NIST Encryption               |
+| 755        |         |                                   |
+| 756        |         |                                   |
+| 757        | HONEY   | HoneyWood                         |
+| 758        | XDD     | XDDCoin                           |
+| 759        | TBI     | TBicloud                          |
+| 760        | FGC     | Figcoin                           |
+| 761        |         |                                   |
+| 762        | BELLS   | Bellscoin                         |
+| 763        |         |                                   |
+| 764        |         |                                   |
+| 765        | TGN     | Tagion                            |
+| 766        |         |                                   |
+| 767        | LLD     | Liberland                         |
+| 768        | BALLZ   | Ballzcoin                         |
+| 769        |         |                                   |
+| 770        | COSA    | Cosanta                           |
+| 771        | BR      | BR                                |
+| 772        |         |                                   |
+| 773        | CSB     | CosmoBliss                        |
+| 774        |         |                                   |
+| 775        | PLSR    | Pulsar Coin                       |
+| 776        | KEY     | Keymaker Coin                     |
+| 777        | BTW     | Bitcoin World                     |
+| 778        |         |                                   |
+| 779        | UCHAIN  | UCHAIN                            |
+| 780        | PLCUC   | PLC Ultima Classic                |
+| 781        | PLCUX   | PLC Ultima X                      |
+| 782        | PLCU    | PLC Ultima                        |
+| 783        | SMARTBC | SMART Blockchain                  |
+| 784        | SUI     | Sui                               |
+| 785        | ULTIMA  | ULTIMA                            |
+| 786        | UIDD    | UIDD                              |
+| 787        | ACA     | Acala                             |
+| 788        | BNC     | Bifrost                           |
+| 789        | TAU     | Lamden                            |
+| 790        | LKY     | Luckycoin                         |
+| 791        | SOMA    | Soma                              |
+| 792        |         |                                   |
+| 793        |         |                                   |
+| 794        | INTR    | Interlay                          |
+| 795        | KINT    | Kintsugi                          |
+| 796        |         |                                   |
+| 797        | MVRX    | Muvor ERP                         |
+| 798        |         |                                   |
+| 799        | PDEX    | Polkadex                          |
+| 800        | BEET    | Beetle Coin                       |
+| 801        | DST     | DSTRA                             |
+| 802        | CY      | Cyberyen                          |
+| 803        | RYME    | Ryme Network                      |
+| 804        | ZKS     | zkSync                            |
+| 805        | SCASH   | Scash                             |
+| 806        |         |                                   |
+| 807        |         |                                   |
+| 808        | QVT     | Qvolta                            |
+| 809        | SDN     | Shiden Network                    |
+| 810        | ASTR    | Astar Network                     |
+| 811        | ---     | reserved                          |
+| 812        |         |                                   |
+| 813        | MEER    | Qitmeer                           |
+| 814        |         |                                   |
+| 815        | FACT    | ImFACT                            |
+| 816        | FSC     | FSC                               |
+| 817        |         |                                   |
+| 818        | VET     | VeChain Token                     |
+| 819        | REEF    | Reef                              |
+| 820        | CLO     | Callisto                          |
+| 821        |         |                                   |
+| 822        | BDB     | BigchainDB                        |
+| 823        | TBL     | TBLINK                            |
+| 824        | RBNT    | Redbelly Network                  |
+| 825        |         |                                   |
+| 826        | YBC     | YBChain                           |
+| 827        | ACE     | Endurance                         |
+| 828        | CCN     | ComputeCoin                       |
+| 829        | BBA     | BBACHAIN                          |
+| 830        |         |                                   |
+| 831        | CRUZ    | cruzbit                           |
+| 832        | SAPP    | Sapphire                          |
+| 833        | 777     | Jackpot                           |
+| 834        | KYAN    | Kyanite                           |
+| 835        | AZR     | Azzure                            |
+| 836        | CFL     | CryptoFlow                        |
+| 837        | DASHD   | Dash Diamond                      |
+| 838        | TRTT    | Trittium                          |
+| 839        | UCR     | Ultra Clear                       |
+| 840        | PNY     | Peony                             |
+| 841        | BECN    | Beacon                            |
+| 842        | MONK    | Monk                              |
+| 843        | SAGA    | CryptoSaga                        |
+| 844        | SUV     | Suvereno                          |
+| 845        | ESK     | EskaCoin                          |
+| 846        | OWO     | OneWorld Coin                     |
+| 847        | PEPS    | PEPS Coin                         |
+| 848        | BIR     | Birake                            |
+| 849        | MOBIC   | MobilityCoin                      |
+| 850        | FLS     | Flits                             |
+| 851        | FRECO   | Freco                             |
+| 852        | DSM     | Desmos                            |
+| 853        | PRCY    | PRCY Coin                         |
+| 854        |         |                                   |
+| 855        |         |                                   |
+| 856        | TB      | TBCoin                            |
+| 857        |         |                                   |
+| 858        | HVH     | HAVAH                             |
+| 859        |         |                                   |
+| 860        | XBIT    | XBIT Coin                         |
+| 861        |         |                                   |
+| 862        |         |                                   |
+| 863        |         |                                   |
+| 864        | CVM     | Convex                            |
+| 865        |         |                                   |
+| 866        | MOB     | MobileCoin                        |
+| 867        |         |                                   |
+| 868        | IF      | Infinitefuture                    |
+| 869        | TXFLOW  | TxFlow                            |
+| 870        |         |                                   |
+| 871        |         |                                   |
+| 872        |         |                                   |
+| 873        | QUORUM  | Quorum                            |
+| 874        |         |                                   |
+| 875        |         |                                   |
+| 876        |         |                                   |
+| 877        | NAM     | Namada                            |
+| 878        | SCR     | Scorum Network                    |
+| 879        |         |                                   |
+| 880        | LUM     | Lum Network                       |
+| 881        | AEGS    | Aegisum                           |
+| 882        |         |                                   |
+| 883        | ZBC     | ZooBC                             |
+| 884        |         |                                   |
+| 885        | XCN     | XCoin                             |
+| 886        | ADF     | AD Token                          |
+| 887        |         |                                   |
+| 888        | NEO     | NEO                               |
+| 889        | TOMO    | TOMO                              |
+| 890        | XSEL    | Seln                              |
+| 891        |         |                                   |
+| 892        |         |                                   |
+| 893        |         |                                   |
+| 894        |         |                                   |
+| 895        |         |                                   |
+| 896        | LKSC    | LKSCoin                           |
+| 897        |         |                                   |
+| 898        | AS      | Assetchain                        |
+| 899        | XEC     | eCash                             |
+| 900        | LMO     | Lumeneo                           |
+| 901        | NXT     | NxtMeta                           |
+| 902        |         |                                   |
+| 903        | EGN     | EGAHN Intelligence Network        |
+| 904        | HNT     | Helium                            |
+| 905        |         |                                   |
+| 906        | XPX     | Sirius                            |
+| 907        | FIS     | StaFi                             |
+| 908        |         |                                   |
+| 909        | SGE     | Saage                             |
+| 910        |         |                                   |
+| 911        | GERT    | Gert                              |
+| 912        |         |                                   |
+| 913        | VARA    | Vara Network                      |
+| 914        |         |                                   |
+| 915        |         |                                   |
+| 916        | META    | Metadium                          |
+| 917        | FRA     | Findora                           |
+| 918        |         |                                   |
+| 919        | CCD     | Concordium                        |
+| 920        |         |                                   |
+| 921        | AVN     | Avian Network                     |
+| 922        |         |                                   |
+| 923        |         |                                   |
+| 924        |         |                                   |
+| 925        | DIP     | Dipper Network                    |
+| 926        |         |                                   |
+| 927        |         |                                   |
+| 928        | GHM     | HermitMatrixNetwork               |
+| 929        |         |                                   |
+| 930        |         |                                   |
+| 931        | RUNE    | THORChain (RUNE)                  |
+| 932        |         |                                   |
+| 933        |         |                                   |
+| 934        |         |                                   |
+| 935        |         |                                   |
+| 936        |         |                                   |
+| 937        |         |                                   |
+| 938        | MGO     | Mango Network                     |
+| 939        | AB      | Argot Protocol                    |
+| 940        |         |                                   |
+| 941        | ---     | reserved                          |
+| 942        | KCN     | Kylacoin                          |
+| 943        | LCN     | Lyncoin                           |
+| 944        |         |                                   |
+| 945        | UNLOCK  | Jasiri protocol                   |
+| 946        |         |                                   |
+| 947        |         |                                   |
+| 948        |         |                                   |
+| 949        |         |                                   |
+| 950        | CNDT    | Conduct Protocol                  |
+| 951        |         |                                   |
+| 952        |         |                                   |
+| 953        |         |                                   |
+| 954        |         |                                   |
+| 955        | LTP     | LifetionCoin                      |
+| 956        |         |                                   |
+| 957        |         |                                   |
+| 958        |         | KickSoccer                        |
+| 959        |         |                                   |
+| 960        | VKAX    | Vkax                              |
+| 961        |         |                                   |
+| 962        |         |                                   |
+| 963        | SYL     | OpenSY                            |
+| 964        |         |                                   |
+| 965        | ATLA    | Atleta Network                    |
+| 966        | MATIC   | Matic                             |
+| 967        |         |                                   |
+| 968        | UNW     | UNW                               |
+| 969        | QI      | Quai Network                      |
+| 970        | TWINS   | TWINS                             |
+| 971        |         |                                   |
+| 972        |         |                                   |
+| 973        |         |                                   |
+| 974        |         |                                   |
+| 975        |         | TrustNet                          |
+| 976        |         |                                   |
+| 977        | TLOS    | Telos                             |
+| 978        |         |                                   |
+| 979        |         |                                   |
+| 980        |         |                                   |
+| 981        | TAFECO  | Taf ECO Chain                     |
+| 982        |         |                                   |
+| 983        |         |                                   |
+| 984        |         |                                   |
+| 985        | AU      | Autonomy                          |
+| 986        |         |                                   |
+| 987        | VCG     | VipCoin                           |
+| 988        | XAZAB   | Xazab core                        |
+| 989        | AIOZ    | AIOZ                              |
+| 990        | CORE    | TX                                |
+| 991        | PEC     | Phoenix                           |
+| 992        | UNT     | Unit                              |
+| 993        | XRB     | X Currency                        |
+| 994        | QUAI    | Quai Network                      |
+| 995        | CAPS    | Ternoa                            |
+| 996        | OKT     | OKChain Token                     |
+| 997        | SUM     | Solidum                           |
+| 998        | LBTC    | Lightning Bitcoin                 |
+| 999        | BCD     | Bitcoin Diamond                   |
+| 1000       | BTN     | Bitcoin New                       |
+| 1001       | TT      | ThunderCore                       |
+| 1002       | BKT     | BanKitt                           |
+| 1003       | NODL    | Nodle                             |
+| 1004       | PCOIN   | PCOIN                             |
+| 1005       | TAO     | Bittensor                         |
+| 1006       | HSK     | HashKey Chain                     |
+| 1007       | FTM     | Fantom                            |
+| 1008       | RPG     | RPG                               |
+| 1009       | LAKE    | iconLake                          |
+| 1010       | HT      | Huobi ECO Chain                   |
+| 1011       | ELV     | Eluvio                            |
+| 1012       | JOC     | Japan Open Chain                  |
+| 1013       | BIC     | Beincrypto                        |
+| 1014       | JOY     | Joystream                         |
+| 1015       | ZCX     | ZEN Exchange Token                |
+| 1016       | ---     | reserved                          |
+| 1017       | ZTC     | Zenchain                          |
+| 1018       | ZANO    | Zano                              |
+| 1019       | GEEQ    | Geeq                              |
+| 1019       | ZENO    | Zenotta                           |
+| 1020       | EVC     | Evrice                            |
+| 1021       | PKOIN   | Pocketcoin                        |
+| 1022       | XRD     | Radix DLT                         |
+| 1023       | ONE     | HARMONY-ONE (Legacy)              |
+| 1024       | ONT     | Ontology                          |
+| 1025       | CZZ     | Classzz                           |
+| 1026       | KEX     | Kira Exchange Token               |
+| 1027       | MCM     | Mochimo                           |
+| 1028       | PLS     | Pulse Coin                        |
+| 1032       | BTCR    | BTCR                              |
+| 1042       | MFID    | Moonfish ID                       |
+| 1100       | CROSS   | Cross Chain                       |
+| 1110       | ZRA     | ZERA                              |
+| 1111       | BBC     | Big Bitcoin                       |
+| 1116       | CORE    | Core                              |
+| 1120       | RISE    | RISE                              |
+| 1122       | CMT     | CyberMiles Token                  |
+| 1128       | ETSC    | Ethereum Social                   |
+| 1129       | DFI     | DeFiChain                         |
+| 1130       | DFI     | DeFiChain EVM Network             |
+| 1134       | MESH    | StateMesh                         |
+| 1137       | $DAG    | Constellation Labs                |
+| 1145       | CDY     | Bitcoin Candy                     |
+| 1155       | ENJ     | Enjin Coin                        |
+| 1170       | HOO     | Hoo Smart Chain                   |
+| 1200       | GNK     | Gonka                             |
+| 1234       | ALPH    | Alephium                          |
+| 1236       |         | Masca                             |
+| 1237       |         | Nostr                             |
+| 1238       |         | SSH                               |
+| 1239       |         | OpenPGP                           |
+| 1240       |         | X.509                             |
+| 1241       |         | WireGuard                         |
+| 1280       |         | Kudos Setler                      |
+| 1284       | GLMR    | Moonbeam                          |
+| 1285       | MOVR    | Moonriver                         |
+| 1286       | DSG     | Dessage Social Protocol           |
+| 1298       | WPC     | Wpc                               |
+| 1308       | WEI     | WEI                               |
+| 1312       | BITS    | Entropy                           |
+| 1313       | GAEL    | Gaelium                           |
+| 1331       | NACKL   | Acki Nacki                        |
+| 1337       | DFC     | Defcoin                           |
+| 1338       | IRON    | Iron Fish                         |
+| 1339       | WNSD    | Winsdet                           |
+| 1348       | ISLM    | IslamicCoin                       |
+| 1397       | HYC     | Hycon                             |
+| 1410       | TENTSLP | TENT Simple Ledger Protocol       |
+| 1420       | DEV     | DogecoinEV                        |
+| 1447       | DNR     | Dinero                            |
+| 1448       | DIN     | Dinero v7                         |
+| 1510       | XSC     | XT Smart Chain                    |
+| 1512       | AAC     | Double-A Chain                    |
+| 1524       |         | Taler                             |
+| 1533       | BEAM    | Beam                              |
+| 1536       | GAS     | BubiChain                         |
+| 1540       | ATHENA  | Athena                            |
+| 1551       | SDK     | Sovereign SDK                     |
+| 1555       | APC     | Apc Chain                         |
+| 1616       | ELF     | AELF                              |
+| 1618       | AUDL    | AUDL                              |
+| 1620       | ATH     | Atheios                           |
+| 1627       | LUME    | Lume Web                          |
+| 1642       | NEW     | Newton                            |
+| 1657       | BTA     | Btachain                          |
+| 1668       | NEOX    | Neoxa                             |
+| 1669       | MEWC    | Meowcoin                          |
+| 1688       | BCX     | BitcoinX                          |
+| 1707       | TRMP    | TrumPOW                           |
+| 1729       | XTZ     | Tezos                             |
+| 1776       | LBTC    | Liquid BTC                        |
+| 1777       | BBP     | Biblepay                          |
+| 1784       | JPYS    | JPY Stablecoin                    |
+| 1788       | USVAC   | USVACoin                          |
+| 1789       | VEGA    | Vega Protocol                     |
+| 1815       | ADA     | Cardano                           |
+| 1818       | CUBE    | Cube Chain Native Token           |
+| 1842       | LIF     | Lifcoin                           |
+| 1888       | ZTX     | Zetrix                            |
+| 1899       | XEC     | eCash token                       |
+| 1900       | XNA     | Neurai                            |
+| 1901       | CLC     | Classica                          |
+| 1907       | BITCI   | Bitcicoin                         |
+| 1918       | BKC     | Briskcoin                         |
+| 1919       | VIPS    | VIPSTARCOIN                       |
+| 1926       | CITY    | City Coin                         |
+| 1935       | HRC     | Hypercoin                         |
+| 1948       | DSV     | Doriancoin                        |
+| 1951       | ESA     | Esa                               |
+| 1952       | ESC     | EsaCoin                           |
+| 1955       | XX      | xx coin                           |
+| 1969       | MVRK    | Mavryk Network                    |
+| 1977       | XMX     | Xuma                              |
+| 1984       | TRTL    | TurtleCoin                        |
+| 1985       | SLRT    | Solarti Chain                     |
+| 1986       | QTH     | Qing Tong Horizon                 |
+| 1987       | EGEM    | EtherGem                          |
+| 1988       | MIRA    | Mira Chain                        |
+| 1989       | HODL    | HOdlcoin                          |
+| 1990       | PHL     | Placeholders                      |
+| 1991       | SC      | Sia                               |
+| 1995       | MYDOGE  | Mydogecoin                        |
+| 1996       | MYT     | Mineyourtime                      |
+| 1997       | POLIS   | Polis                             |
+| 1998       | XMCC    | Monoeci                           |
+| 1999       | COLX    | ColossusXT                        |
+| 2000       | GIN     | GinCoin                           |
+| 2001       | MNP     | MNPCoin                           |
+| 2002       | MLN     | Miraland                          |
+| 2003       | ISNA    | iSarrana                          |
+| 2010       | XBT     | Bitcoin Classic                   |
+| 2013       | JKC     | Junkcoin                          |
+| 2015       | TEER    | Integritee                        |
+| 2017       | KIN     | Kin                               |
+| 2018       | EOSC    | EOSClassic                        |
+| 2019       | GBT     | GoldBean Token                    |
+| 2020       | PKC     | PKC                               |
+| 2021       | SKT     | Sukhavati                         |
+| 2022       | XHT     | Xinghuo Token                     |
+| 2023       | COC     | Chat On Chain                     |
+| 2024       | USBC    | Universal Ledger USBC             |
+| 2025       | ROCK    | Zenrock Labs                      |
+| 2026       | ASTRON  | ASTRON Token                      |
+| 2027       | UNC     | UniCash                           |
+| 2046       | ANY     | Any                               |
+| 2048       | MCASH   | MCashChain                        |
+| 2049       | TRUE    | TrueChain                         |
+| 2050       | MOVO    | Movo Smart Chain                  |
+| 2086       | KILT    | KILT Spiritnet                    |
+| 2091       | FRQCY   | Frequency                         |
+| 2102       | LC2     | LitecoinII                        |
+| 2109       | SAMA    | Exosama Network                   |
+| 2112       | IoTE    | IoTE                              |
+| 2121       | CBTC    | Coordinate BTC (Anduro)           |
+| 2122       | QBTC    | Quasar BTC (Anduro)               |
+| 2125       | BAY     | BitBay                            |
+| 2137       | XRG     | Ergon                             |
+| 2199       | SAMA    | Moonsama Network                  |
+| 2221       | ASK     | ASK                               |
+| 2222       | CWEB    | Coinweb                           |
+| 2285       |         | Qiyi Chain                        |
+| 2301       | QTUM    | QTUM                              |
+| 2302       | ETP     | Metaverse                         |
+| 2303       | GXC     | GXChain                           |
+| 2304       | CRP     | CranePay                          |
+| 2305       | ELA     | Elastos                           |
+| 2338       | SNOW    | Snowblossom                       |
+| 2365       | XIN     | Mixin                             |
+| 2457       | HYPE    | Hyperliquid                       |
+| 2500       | NEXI    | Nexi                              |
+| 2570       | AOA     | Aurora                            |
+| 2626       | AOXC    | AOXCHAIN                          |
+| 2686       | AIPG    | AIPowerGrid                       |
+| 2718       | NAS     | Nebulas                           |
+| 2809       | LAN     | Lanify                            |
+| 2894       | REOSC   | REOSC Ecosystem                   |
+| 2941       | BND     | Blocknode                         |
+| 3000       | SM      | Stealth Message                   |
+| 3003       | LUX     | LUX                               |
+| 3030       | HBAR    | Hedera HBAR                       |
+| 3054       | HIVE    | Hive Blockchain                   |
+| 3073       | MOVE    | Movement                          |
+| 3077       | COS     | Contentos                         |
+| 3131       | DIP     | Dipnet Blockchain                 |
+| 3141       | B1T     | Bit                               |
+| 3276       | CCC     | CodeChain                         |
+| 3333       | SXP     | Solar                             |
+| 3338       | PEAQ    | peaq                              |
+| 3344       | PLMC    | Polimec                           |
+| 3377       | ROI     | ROIcoin                           |
+| 3381       | DYN     | Dynamic                           |
+| 3383       | SEQ     | Sequence                          |
+| 3434       | PEPE    | Pepecoin Core                     |
+| 3499       | BLAZE   | Blaze                             |
+| 3501       | JFIN    | JFIN Coin                         |
+| 3552       | DEO     | Destocoin                         |
+| 3564       | DST     | DeStream                          |
+| 3601       | CY      | Cybits                            |
+| 3630       | EPPIE   | Eppie                             |
+| 3757       | MPC     | Partisia Blockchain               |
+| 3840       | RED     | ReDeFi RED                        |
+| 4040       | FC8     | FCH Network                       |
+| 4096       | YEE     | YeeCo                             |
+| 4134       | DMD     | DebitMyData                       |
+| 4218       | IOTA    | IOTA                              |
+| 4219       | SMR     | Shimmer                           |
+| 4242       | AXE     | Axe                               |
+| 4298       | LOCA    | Loca                              |
+| 4343       | XYM     | Symbol                            |
+| 4444       | C4E     | Chain4Energy                      |
+| 4474       | SHIC    | ShibaCoin                         |
+| 4646       | MST     | MST                               |
+| 4919       | XVM     | Venidium                          |
+| 4976       | VARA    | Vara                              |
+| 4999       | BXN     | BlackFort Exchange Network        |
+| 5000       | V12     | Vet The Vote                      |
+| 5006       | SBC     | Senior Blockchain                 |
+| 5042       | USDC    | Arc                               |
+| 5248       | FIC     | FIC                               |
+| 5353       | HNS     | Handshake                         |
+| 5404       | ISK     | ISKRA                             |
+| 5467       | ALTME   | ALTME                             |
+| 5555       | FUND    | Unification                       |
+| 5757       | STX     | Stacks                            |
+| 5895       | VOW     | VowChain VOW                      |
+| 5920       | SLU     | SILUBIUM                          |
+| 5995       | DUSK    | Dusk Network                      |
+| 6060       | GO      | GoChain GO                        |
+| 6144       | DTS     | Datos                             |
+| 6174       | MOI     | My Own Internet                   |
+| 6278       | STEAMX  | Rails Network Mainnet             |
+| 6310       | VRL     | Virel Protocol                    |
+| 6383       | NEUE    | Dap                               |
+| 6532       | UM      | Penumbra                          |
+| 6599       | RSC     | Royal Sports City                 |
+| 6666       | BPA     | Bitcoin Pizza                     |
+| 6688       | SAFE    | SAFE                              |
+| 6767       | CC      | Canton Coin                       |
+| 6779       | COTI    | COTI                              |
+| 6969       | ROGER   | TheHolyrogerCoin                  |
+| 7000       | ZETA    | ZetaChain                         |
+| 7007       | SVRN7   | Web 7.0 Sovrona                   |
+| 7027       | ELLA    | Ella the heart                    |
+| 7028       | AA      | Arthera                           |
+| 7070       | DOI     | Doichain                          |
+| 7091       | TOPL    | Topl                              |
+| 7272       | ABTC    | Alys BTC (Anduro)                 |
+| 7331       | KLY     | KLYNTAR                           |
+| 7341       | SHFT    | Shyft                             |
+| 7518       | MEV     | MEVerse                           |
+| 7576       | ADIL    | ADIL Chain                        |
+| 7777       | BTV     | Bitvote                           |
+| 7779       | CPV     | Compverse                         |
+| 8000       | SKY     | Skycoin                           |
+| 8008       | BERA    | Berachain                         |
+| 8017       | ISC     | iSunCoin                          |
+| 8080       |         | DSRV                              |
+| 8181       | BOC     | BeOne Chain                       |
+| 8192       | PAC     | pacprotocol                       |
+| 8217       | KAIA    | KAIA                              |
+| 8282       | HANEUL  | Haneul                            |
+| 8327       | RXB     | Record X-core Blockchain          |
+| 8339       | BTQ     | BitcoinQuark                      |
+| 8444       | XCH     | Chia                              |
+| 8453       |         | Base                              |
+| 8520       | ---     | reserved                          |
+| 8680       | PLMNT   | Planetmint                        |
+| 8732       | BLN     | Bullions                          |
+| 8738       | ALPH    | Alph Network                      |
+| 8800       | AIIR    | BitAiir                           |
+| 8866       | GGX     | Golden Gate                       |
+| 8886       | GGXT    | Golden Gate Sydney                |
+| 8887       | KTA     | Keeta                             |
+| 8888       | SBTC    | Super Bitcoin                     |
+| 8964       | NULS    | NULS                              |
+| 8997       | BBC     | Babacoin                          |
+| 8998       | JGC     | JagoanCoin                        |
+| 8999       | BTP     | Bitcoin Pay                       |
+| 9000       | AVAX    | Avalanche                         |
+| 9001       | ARB1    | Arbitrum                          |
+| 9002       | BOBA    | Boba                              |
+| 9003       | LOOP    | Loopring                          |
+| 9004       | STRK    | StarkNet                          |
+| 9005       | AVAXC   | Avalanche C-Chain                 |
+| 9006       | BSC     | Binance Smart Chain               |
+| 9007       | SATOX   | Satoxcoin                         |
+| 9333       | B3C     | B3Chain                           |
+| 9345       | WEIL    | Weilliptic                        |
+| 9508       | VARTA   | Monetarium                        |
+| 9555       | RIN     | Rincoin                           |
+| 9797       | NRG     | Energi                            |
+| 9888       | BTF     | Bitcoin Faith                     |
+| 9969       | OSMI    | Osmium                            |
+| 9999       | GOD     | Bitcoin God                       |
+| 10000      | FO      | FIBOS                             |
+| 10001      | SPACE   | Space                             |
+| 10007      | S       | SONIC                             |
+| 10111      | DHP     | dHealth                           |
+| 10226      | RTM     | Raptoreum                         |
+| 10242      | AA      | Arthera                           |
+| 10291      | XRC     | XRhodium                          |
+| 10507      | NUM     | Numbers Protocol                  |
+| 10605      | XPI     | Lotus                             |
+| 11111      | ESS     | Essentia One                      |
+| 11742      | VARCH   | InvArch                           |
+| 11743      | TNKR    | Tinkernet                         |
+| 11995      | AURE    | Aureus                            |
+| 12345      | IPOS    | IPOS                              |
+| 12586      | MINA    | Mina                              |
+| 12850      | ANLOG   | Analog Timechain                  |
+| 13107      | BTY     | BitYuan                           |
+| 13108      | YCC     | Yuan Chain Coin                   |
+| 13381      | PHX     | Phoenix                           |
+| 14001      | WAX     | Worldwide Asset Exchange          |
+| 14159      | FBC     | Fistbump                          |
+| 15845      | SDGO    | SanDeGo                           |
+| 16181      | XTX     | Totem Live Network                |
+| 16754      | ARDR    | Ardor                             |
+| 18000      | MTR     | Meter                             |
+| 18888      | BTGS    | BitcoinGold                       |
+| 19165      | SAFE    | Safecoin                          |
+| 19167      | FLUX    | Flux                              |
+| 19169      | RITO    | Ritocoin                          |
+| 19788      | ML      | Mintlayer                         |
+| 19999      | CS      | Cloud Service                     |
+| 20036      | XND     | ndau                              |
+| 20760      | WJK     | WojakCoin                         |
+| 21004      | C4EI    | c4ei                              |
+| 21337      | XAH     | Xahau                             |
+| 21888      | PAC     | Pactus                            |
+| 22504      | PWR     | PWRcoin                           |
+| 23000      | EPIC    | Epic Cash                         |
+| 25252      | BELL    | Bellcoin                          |
+| 25718      | CHX     | Own                               |
+| 26417      | G1      | Ğ1                                |
+| 28465      | BTCC    | Bitcoin-Classic                   |
+| 29223      | NEXA    | Nexa                              |
+| 30001      | ---     | reserved                          |
+| 31102      | ESN     | EtherSocial Network               |
+| 31337      |         | ThePower                          |
+| 33416      | TEO     | Trust Eth reOrigin                |
+| 33878      | BTCS    | Bitcoin Stake                     |
+| 34952      | BTT     | ByteTrade                         |
+| 36969      | AMA     | AMA                               |
+| 37992      | FXTC    | FixedTradeCoin                    |
+| 39321      | AMA     | Amabig                            |
+| 42069      | FACT    | FACT0RN                           |
+| 43028      | AXIV    | AXIV                              |
+| 47803      | BAX     | BAX                               |
+| 49262      | EVE     | evan                              |
+| 49344      | STASH   | STASH                             |
+| 52752      | CELO    | Celo                              |
+| 54176      | OVER    | OverProtocol                      |
+| 61616      | TH      | TianHe                            |
+| 61888      | MORM    | Morpheum                          |
+| 65536      | KETH    | Krypton World                     |
+| 68291      | CERA    | CERA                              |
+| 69420      | GRLC    | Garlicoin                         |
+| 70007      | GWL     | Gewel                             |
+| 77777      | ZYN     | Wethio                            |
+| 83293      | QUBIC   | Qubic                             |
+| 88888      | RYO     | c0ban                             |
+| 99999      | WICC    | Waykichain                        |
+| 100500     | HOME    | HomeCoin                          |
+| 101010     | STC     | Starcoin                          |
+| 104109     |         | Seed Hypermedia                   |
+| 105105     | STRAX   | Strax                             |
+| 111111     | KAS     | Kaspa                             |
+| 121337     | KLS     | Karlsen                           |
+| 123456     | SPR     | Spectre                           |
+| 130822     | WBT     | WhiteBIT Coin                     |
+| 140586     | BEX     | BEXChain                          |
+| 161803     | APTA    | Bloqs4Good                        |
+| 189189     | QUAN    | Quantus Network                   |
+| 190301     | LOCUS   | Locus Chain                       |
+| 200625     | AKA     | Akroma                            |
+| 200901     | BTR     | Bitlayer                          |
+| 224433     | CONET   | CONET Holesky Network             |
+| 246529     | ATS     | ARTIS sigma1                      |
+| 251022     | AUTOX   | Autox Coin                        |
+| 261131     | ZAMA    | Zama                              |
+| 314159     | PI      | Pi Network                        |
+| 333332     | VALUE   | Value Chain                       |
+| 333333     | 3333    | Pi Value Consensus                |
+| 424242     | X42     | x42                               |
+| 440017     | @G      | Graphite                          |
+| 534352     | SCR     | Scroll                            |
+| 666666     | VITE    | Vite                              |
+| 696365     | ICE     | Ice Network                       |
+| 696969     | TXC     | TEXITcoin                         |
+| 827166     |         | RGB on Bitcoin (mainnet)          |
+| 827167     |         | RGB on Bitcoin (testnet)          |
+| 828942     |         | RGB on Liquid (mainnet)           |
+| 888888     | SEA     | Second Exchange Alliance          |
+| 969696     | ISK     | Iskander Coin                     |
+| 1048576    | AMAX    | Armonia Meta Chain                |
+| 1171337    | ILT     | iOlite                            |
+| 1313114    | ETHO    | Etho Protocol                     |
+| 1313500    | XERO    | Xerom                             |
+| 1712144    | LAX     | LAPO                              |
+| 3924011    | EPK     | EPIK Protocol                     |
+| 4151811    | DORK    | Dorkcoin                          |
+| 4353123    | BBLU    | Bitcoin-Blu                       |
+| 4392018    | MCSH    | MetaMask Cash Account             |
+| 4741444    | HYD     | Hydra Token                       |
+| 5063758    |         | Miden                             |
+| 5249353    | BCO     | BitcoinOre                        |
+| 5249354    | BHD     | BitcoinHD                         |
+| 5264462    | PTN     | PalletOne                         |
+| 5655640    | VLX     | Velas                             |
+| 5718350    | WAN     | Wanchain                          |
+| 5741564    | WAVES   | Waves                             |
+| 5741565    | WEST    | Waves Enterprise                  |
+| 6382179    | ABC     | Abcmint                           |
+| 6517357    | CRM     | Creamcoin                         |
+| 7171666    | BROCK   | Bitrock                           |
+| 7562605    | SEM     | Semux                             |
+| 7567736    | ION     | ION                               |
+| 7777777    | FCT     | FirmaChain                        |
+| 7825266    | WGR     | WGR                               |
+| 7825267    | OBSR    | OBServer                          |
+| 8163271    | AFS     | ANFS                              |
+| 8163321    | BTCV    | Bitcoin-Value                     |
+| 10000118   | OSMO    | Osmosis                           |
+| 11259375   | LBR     | 0L                                |
+| 15118976   | XDS     | XDS                               |
+| 19000118   | SEI     | SEI                               |
+| 20230101   | ROH     | Rooch                             |
+| 20240430   | NLK     | NuLinkCoin                        |
+| 20260424   | SOLEN   | Solen                             |
+| 22000118   | DYDX    | Dydx                              |
+| 22000119   | INJ     | Injective                         |
+| 35600000   | AXX     | AtlasX Chain                      |
+| 61717561   | AQUA    | Aquachain                         |
+| 77777777   | AZT     | Aztecoin                          |
+| 88888888   | HATCH   | Hatch                             |
+| 91927009   | kUSD    | kUSD                              |
+| 99999996   | GENS    | GENS                              |
+| 99999997   | EQ      | EQ                                |
+| 99999998   | FLUID   | Fluid Chains                      |
+| 99999999   | QKC     | QuarkChain                        |
+| 240079435  | ZORK    | Zork Network                      |
+| 268435779  | MON     | Monad                             |
+| 608589380  | FVDC    | ForumCoin                         |
+| 1010101010 | FAIC    | Free AI Chain                     |
+| 1179993420 |         | Fuel                              |
+| 1179993421 | TTNC    | TakeTitan                         |
+| 1179993431 | MTGBP   | MTGBP                             |
+| 1179993441 | QFS     | Qfs                               |
+| 1179993451 | RWA     | Asset Chain                       |
+| 1179993461 | HXC     | HuaXia Chain                      |
+| 1179993471 | AME     | AME Chain                         |
+| 1414421071 | TNZO    | Tenzro                            |
+| 1869902945 | ATTO    | Atto                              |
+| 1869902946 | CTA     | Crypterra                         |
+| 1869902947 | SOST    | Sovereign Stock Token             |
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
The SLIP44 format changed, making our automatic update job fail, this PR adjusts the build script for it and updates the JSON file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect derived BIP-44 coin-type hex values used by consumers of slip44.json; incorrect parsing or hex math could mis-route wallet derivations for affected coins.
> 
> **Overview**
> Upstream **SLIP-0044** dropped the hex column from its registry table, so the **`src/build.js`** generator no longer parses a `0x…` field from `slip44.md`. It now reads **coin type, symbol, and name**, derives hardened coin type as **`0x80000000 | index`**, and skips rows with empty symbol and name.
> 
> **`slip44.json`** is regenerated from that logic: many **new coin-type entries** are added, and **hex values are updated** where they no longer match the computed formula (e.g. Morpheum, Ice Network, Osmosis). One existing entry’s hex is normalized to lowercase (`0x800010ca` for Loca).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd99a88bb64451a7a312bc982da64648657e233b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->